### PR TITLE
Fixed incomplete UBX CFG-MSG message

### DIFF
--- a/src/rcv/ublox.c
+++ b/src/rcv/ublox.c
@@ -345,7 +345,7 @@ extern int input_ubxf(raw_t *raw, FILE *fp)
 * args   : char  *msg   IO     message string 
 *            "CFG-PRT   portid res0 res1 mode baudrate inmask outmask flags"
 *            "CFG-USB   vendid prodid res1 res2 power flags vstr pstr serino"
-*            "CFG-MSG   msgid rate0 rate1 rate2 rate3"
+*            "CFG-MSG   msgid rate0 rate1 rate2 rate3 rate4 rate5"
 *            "CFG-NMEA  filter version numsv flags"
 *            "CFG-RATE  meas nav time"
 *            "CFG-CFG   clear_mask save_mask load_mask"
@@ -380,7 +380,7 @@ extern int gen_ubx(const char *msg, unsigned char *buff)
     const int prm[][32]={
         {FU1,FU1,FU2,FU4,FU4,FU2,FU2,FU2,FU2},    /* PRT */
         {FU2,FU2,FU2,FU2,FU2,FU2,FS32,FS32,FS32}, /* USB */
-        {FU1,FU1,FU1,FU1,FU1,FU1},                /* MSG */
+        {FU1,FU1,FU1,FU1,FU1,FU1,FU1,FU1},        /* MSG */
         {FU1,FU1,FU1,FU1},                        /* NMEA */
         {FU2,FU2,FU2},                            /* RATE */
         {FU4,FU4,FU4},                            /* CFG */


### PR DESCRIPTION
It is described in u-blox 6 Protocol Specification that CFG-MSG has length of payload = 8 and consists of:
U1 msgClass
U1 msgID
U1[6] rate for 6 targets

Currently, RTKLIB supports only 4 targets and generates messages such as this:
B5 62 06 01 06 00 02 10 00 00 00 00 1F D1

And even though u-blox receivers accept it, it is impossible to configure messages for two last targets, for example - SPI.

With this fix RTKLIB generates full message supporting all target interfaces:
b5 62 06 01 08 00 02 10 00 00 00 00 01 00 22 25
