### PR TITLE
Hex commands support

### DIFF
--- a/src/rtklib.h
+++ b/src/rtklib.h
@@ -1608,6 +1608,7 @@ extern void strsendcmd(stream_t *stream, const char *cmd);
 extern void strsettimeout(stream_t *stream, int toinact, int tirecon);
 extern void strsetdir(const char *dir);
 extern void strsetproxy(const char *addr);
+int gen_hex(const char *msg, unsigned char *buff);
 
 /* integer ambiguity resolution ----------------------------------------------*/
 extern int lambda(int n, int m, const double *a, const double *Q, double *F,

--- a/src/stream.c
+++ b/src/stream.c
@@ -2186,6 +2186,9 @@ extern void strsendcmd(stream_t *str, const char *cmd)
             else if (!strncmp(msg+1,"LEXR",3)) { /* lex receiver */
                 if ((m=gen_lexr(msg+5,buff))>0) strwrite(str,buff,m);
             }
+			else if (!strncmp(msg+1,"HEX",3)) { /* common hex data as is */
+				if ((m=gen_hex(msg+4,buff))>0) strwrite(str,buff,m);
+			}
         }
         else {
             strwrite(str,(unsigned char *)msg,n);
@@ -2193,4 +2196,35 @@ extern void strsendcmd(stream_t *str, const char *cmd)
         }
         if (*q=='\0') break; else p=q+1;
     }
+}
+
+/* generate hex message -------------------------------------------------
+* generate hex message from message string
+* args   : char  *msg   I      message string
+*          unsigned char *buff O hex message
+* return : length of hex message (0: error)
+*-----------------------------------------------------------------------------*/
+int gen_hex(const char *msg, unsigned char *buff)
+{
+    unsigned char *q=buff;
+	char mbuff[1024],*args[256],*p;
+    unsigned int byte;
+    int iRate,n,narg=0;
+    unsigned char ui100Ms;
+
+	trace(4,"gen_hex: msg=%s\n",msg);
+
+    strcpy(mbuff,msg);
+    for (p=strtok(mbuff," ");p&&narg<256;p=strtok(NULL," ")) {
+        args[narg++]=p;
+	}
+
+	for (n=0;(n<narg);n++) {
+		if (sscanf(args[n], "%2x",&byte))
+			*q++=(unsigned char)byte;
+	}
+
+	n=(int)(q-buff);
+
+	return n;
 }


### PR DESCRIPTION
Hi Takasu,

Firstly let me thank you from Russia for the great open source tool :)
(sorry for my English, just in case)

Recently I started modifying the code to use it with some not supported GNSS receiver.
I hope that some things, that I needed and added before parse its binary protocol, will be useful for others.

I don't have any experience of contribution to opensource projects in GitHub, so if you have time and patience please tell me frankly if I do something wrong.
Is it convenient if I do pull requests step by step (one feature for request)?

First feature I want to suggest is a possibility to send start and stop hex commands, because in last version of rtklib 2.4.2 p7 the only ways to send commands with not ASCII symbols are
1) special packages with special headers for certain receivers (NVS, for example)
2) load binary files (but still can send whole command if there is a null terminated zero byte 0x0 in it).

So relying on your code, I add just a little modification, so now I can send hex command using !HEX option in cmddlg fields.
Example: !HEX 00 01 ab BC ff

Sorry for big text :) and thanks for attention
