### PR TITLE
update str2str and rtkrcv makefile with ctarget options for raspberry pi 2

### DIFF
--- a/app/rtkrcv/gcc/makefile
+++ b/app/rtkrcv/gcc/makefile
@@ -5,6 +5,10 @@ SRC    = ../../../src
 
 # for beagleboard
 #CTARGET= -mfpu=neon -mfloat-abi=softfp -ffast-math
+
+# for raspberry pi 2
+#CTARGET= -march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard
+
 CTARGET= -DENAGLO -DENAQZS -DENACMP -DNFREQ=3
 
 CFLAGS = -Wall -O3 -ansi -pedantic -Wno-unused-but-set-variable -I$(SRC) -I.. -DTRACE $(CTARGET) -g

--- a/app/str2str/gcc/makefile
+++ b/app/str2str/gcc/makefile
@@ -5,6 +5,10 @@ SRC    = ../../../src
 
 # for beagleboard
 #CTARGET= -mfpu=neon -mfloat-abi=softfp -ffast-math
+
+# for raspberry pi 2
+#CTARGET= -march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard
+
 CTARGET=
 
 OPTION = -DENAGLO -DENAGAL -DENAQZS -DENACMP -DTRACE -DNFREQ=3 -DNEXOBS=3


### PR DESCRIPTION
compiled successfully with gcc (Raspbian 4.9.2-10)