### PR TITLE
Define CRTSCTS

### DIFF
--- a/src/stream.c
+++ b/src/stream.c
@@ -52,6 +52,9 @@
 #include <sys/stat.h>
 #include <sys/time.h>
 #define __USE_MISC
+#ifndef CRTSCTS
+#define CRTSCTS  020000000000
+#endif
 #include <errno.h>
 #include <termios.h>
 #include <sys/socket.h>


### PR DESCRIPTION
CRTSCTS is not always defined by __USE_MISC, for example with musl.

Signed-off-by: Nuno Goncalves <nunojpg@gmail.com>