### PR TITLE
Leap seconds file support for convbin and rnx2rtkp

### DIFF
--- a/app/convbin/convbin.c
+++ b/app/convbin/convbin.c
@@ -135,6 +135,8 @@ static const char *help[]={
 "     -l lfile     output RINEX LNAV file",
 "     -s sfile     output SBAS message file",
 "     -trace level output trace level [off]",
+"     -leaps file  leap seconds file \"#  y  m  d  h  m  s  utc-gpst\"",
+"                                    \"1981  7  1  0  0  0        -1\"",
 "",
 " If any output file specified, default output files (<file>.obs,",
 " <file>.nav, <file>.gnav, <file>.hnav, <file>.qnav, <file>.lnav and",
@@ -437,10 +439,10 @@ static int cmdopts(int argc, char **argv, rnxopt_t *opt, char **ifile,
         else if (!strcmp(argv[i],"-s" )&&i+1<argc) ofile[6]=argv[++i];
         else if (!strcmp(argv[i],"-trace" )&&i+1<argc) {
             *trace=atoi(argv[++i]);
-        } /* LFE add leaps file*/
-        else if (!strcmp(argv[i],"--leaps" )&&i+1<argc) {
-            fprintf(stderr,"--leaps detected\n");
+        }
+        else if (!strcmp(argv[i],"-leaps" )&&i+1<argc) {
             read_leaps(argv[++i]);
+            print_leaps();
         }
         else if (!strncmp(argv[i],"-",1)) printhelp();
         
@@ -506,8 +508,6 @@ int main(int argc, char **argv)
     /* parse command line options */
     format=cmdopts(argc,argv,&opt,&ifile,ofile,&dir,&trace);
     
-    print_leaps();
-
     if (!*ifile) {
         fprintf(stderr,"no input file\n");
         return -1;

--- a/app/convbin/convbin.c
+++ b/app/convbin/convbin.c
@@ -437,6 +437,10 @@ static int cmdopts(int argc, char **argv, rnxopt_t *opt, char **ifile,
         else if (!strcmp(argv[i],"-s" )&&i+1<argc) ofile[6]=argv[++i];
         else if (!strcmp(argv[i],"-trace" )&&i+1<argc) {
             *trace=atoi(argv[++i]);
+        } /* LFE add leaps file*/
+        else if (!strcmp(argv[i],"--leaps" )&&i+1<argc) {
+            fprintf(stderr,"--leaps detected\n");
+            read_leaps(argv[++i]);
         }
         else if (!strncmp(argv[i],"-",1)) printhelp();
         
@@ -502,6 +506,8 @@ int main(int argc, char **argv)
     /* parse command line options */
     format=cmdopts(argc,argv,&opt,&ifile,ofile,&dir,&trace);
     
+    print_leaps();
+
     if (!*ifile) {
         fprintf(stderr,"no input file\n");
         return -1;
@@ -521,6 +527,7 @@ int main(int argc, char **argv)
         traceopen(TRACEFILE);
         tracelevel(trace);
     }
+
     stat=convbin(format,&opt,ifile,ofile,dir);
     
     traceclose();

--- a/app/rnx2rtkp/rnx2rtkp.c
+++ b/app/rnx2rtkp/rnx2rtkp.c
@@ -73,6 +73,9 @@ static const char *help[]={
 "           rover latitude/longitude/height for fixed or ppp-fixed mode",
 " -y level  output soltion status (0:off,1:states,2:residuals) [0]",
 " -x level  debug trace level (0:off) [0]"
+" -leaps file  leap seconds file \"#  y  m  d  h  m  s  utc-gpst\"",
+"                                \"1981  7  1  0  0  0        -1\"",
+
 };
 /* show message --------------------------------------------------------------*/
 extern int showmsg(char *format, ...)
@@ -132,6 +135,10 @@ int main(int argc, char **argv)
             te=epoch2time(ee);
         }
         else if (!strcmp(argv[i],"-ti")&&i+1<argc) tint=atof(argv[++i]);
+        else if (!strcmp(argv[i],"-leaps" )&&i+1<argc) {
+            read_leaps(argv[++i]);
+            print_leaps();
+        }
         else if (!strcmp(argv[i],"-k")&&i+1<argc) {++i; continue;}
         else if (!strcmp(argv[i],"-p")&&i+1<argc) prcopt.mode=atoi(argv[++i]);
         else if (!strcmp(argv[i],"-f")&&i+1<argc) prcopt.nf=atoi(argv[++i]);
@@ -182,6 +189,7 @@ int main(int argc, char **argv)
     if (!prcopt.navsys) {
         prcopt.navsys=SYS_GPS|SYS_GLO;
     }
+
     if (n<=0) {
         showmsg("error : no input file");
         return -2;

--- a/src/rtkcmn.c
+++ b/src/rtkcmn.c
@@ -1516,22 +1516,24 @@ extern int read_leaps(const char *file)
     return 1;
 }
 
-/* LFE prints out the leaps table*/
+
+/* print leap seconds table -----------------------------------------------------
+* print leap seconds table
+* args   : none
+* return : none
+* notes  : 
+*-----------------------------------------------------------------------------*/
 extern void print_leaps(void)
 {
     int i;
-
     
-    fprintf(stderr,"Leaps table is:\n");
+    fprintf(stderr,"Leap seconds table:\n");
+    fprintf(stderr,"   y  m  d  h  m  s utc-gpst\n");
     for (i=0;leaps[i][0]>0;i++) {
-        fprintf(stderr,"%f, %f, %f, %f, %f, %f, %f\n", leaps[i][0], leaps[i][1], leaps[i][2], leaps[i][3], leaps[i][4], leaps[i][5], leaps[i][6]);
+        fprintf(stderr,"%4d %2d %2d %2d %2d %2d %3d\n", (int)leaps[i][0], (int)leaps[i][1], (int)leaps[i][2], (int)leaps[i][3], (int)leaps[i][4], (int)leaps[i][5], (int)leaps[i][6]);
     }
+    fprintf(stderr,"\n");
 }
-
-
-
-
-/* LFE */
 
 
 /* gpstime to utc --------------------------------------------------------------

--- a/src/rtkcmn.c
+++ b/src/rtkcmn.c
@@ -1515,6 +1515,25 @@ extern int read_leaps(const char *file)
     fclose(fp);
     return 1;
 }
+
+/* LFE prints out the leaps table*/
+extern void print_leaps(void)
+{
+    int i;
+
+    
+    fprintf(stderr,"Leaps table is:\n");
+    for (i=0;leaps[i][0]>0;i++) {
+        fprintf(stderr,"%f, %f, %f, %f, %f, %f, %f\n", leaps[i][0], leaps[i][1], leaps[i][2], leaps[i][3], leaps[i][4], leaps[i][5], leaps[i][6]);
+    }
+}
+
+
+
+
+/* LFE */
+
+
 /* gpstime to utc --------------------------------------------------------------
 * convert gpstime to utc considering leap seconds
 * args   : gtime_t t        I   time expressed in gpstime

--- a/src/rtklib.h
+++ b/src/rtklib.h
@@ -1431,6 +1431,9 @@ EXPORT double  time2doy (gtime_t t);
 EXPORT double  utc2gmst (gtime_t t, double ut1_utc);
 EXPORT int read_leaps(const char *file);
 
+/* LFE */
+EXPORT void print_leaps(void);
+
 EXPORT int adjgpsweek(int week);
 EXPORT unsigned int tickget(void);
 EXPORT void sleepms(int ms);


### PR DESCRIPTION
With the addition of leap seconds file support to convbin and rnx2rtkp with new "-leaps" command line option, there is no need to recompile them when a new leap second is added.

The tested leap second file format is (# starts a comment) [leapseconds.txt](https://github.com/tomojitakasu/RTKLIB/files/538121/leapseconds.txt) :
\#  y  m  d  h  m  s  utc-gpst
2017  1  1  0  0  0       -18 
2015  7  1  0  0  0       -17 
2012  7  1  0  0  0       -16 
2009  1  1  0  0  0       -15 
2006  1  1  0  0  0       -14 
1999  1  1  0  0  0       -13 
1997  7  1  0  0  0       -12 
1996  1  1  0  0  0       -11 
1994  7  1  0  0  0       -10 
1993  7  1  0  0  0        -9 
1992  7  1  0  0  0        -8 
1991  1  1  0  0  0        -7 
1990  1  1  0  0  0        -6 
1988  1  1  0  0  0        -5 
1985  7  1  0  0  0        -4 
1983  7  1  0  0  0        -3 
1982  7  1  0  0  0        -2 
1981  7  1  0  0  0        -1 