### PR TITLE
Fix UBX-CFG-TMODE3

### DIFF
--- a/src/rcv/ublox.c
+++ b/src/rcv/ublox.c
@@ -13,6 +13,8 @@
 *         Protocol Specification V15.00-17.00, Nov 3, 2014
 *     [4] ublox-AG, UBX-13003221-R09, u-blox 8 /u-blox M8 Receiver Description
 *         including Protocol Specification V15.00-18.00, January, 2016
+*     [5] ublox-AG, UBX-13003221-R013, u-blox 8 /u-blox M8 Receiver Description
+*         including Protocol Specification V15-20.30,22-23.01, July 6, 2017
 *
 * version : $Revision: 1.2 $ $Date: 2008/07/14 00:05:05 $
 * history : 2007/10/08 1.0  new
@@ -1220,7 +1222,8 @@ extern int gen_ubx(const char *msg, unsigned char *buff)
         {FU1,FU1},                                /* RINV */
         {FU1,FU1,FU2,FU2,FU1,FU1,FU2,FU2,FU2,FU2,FU4}, /* SMGR */
         {FU1,FU1,FU2,FI4,FI4,FI4,FU4,FU4,FU4},    /* TMODE2 */
-        {FU1,FU1,FU2,FI4,FI4,FI4,FU4,FU4,FU4},    /* TMODE3 */
+        {FU1,FU1,FU2,FI4,FI4,FI4,FI1,FI1,FI1,FU1,FU4,FU4,FU4,FU1,FU1,FU1,FU1,FU1,
+         FU1,FU1,FU1},                            /* TMODE3 */
         {FU1,FU1,FU1,FU1,FI2,FI2,FU4,FU4,FU4,FU4,FI4,FU4}, /* TPS */
         {FU1,FU1,FU1,FU1,FU4,FU4,FU4,FU4,FU4}     /* TXSLOT */
     };


### PR DESCRIPTION
Format of UBX-CFG-TMODE3 in src/rcv/ublox.c is not correct.

After this change, I got trace log below:

4 gen_ubxf: msg= CFG-TMODE3 0 0 1 0 0 0 0 0 0 0 0 3600 1000 0 0 0 0 0 0 0 0
5 gen_ubx: buff=
B562067128000000 0100000000000000 0000000000000000 000000000000100E 0000E80300000000 000000000000A98C

and after sending UBX-CFG-TMODE3 for ublox NEO-M8P-2, I got UBX-ACK-ACK for this command.

5 input_raw: format=4 data=0xb5
5 input_ubx: data=b5
5 input_raw: format=4 data=0x62
5 input_ubx: data=62
5 input_raw: format=4 data=0x05
5 input_ubx: data=05
5 input_raw: format=4 data=0x01
5 input_ubx: data=01
5 input_raw: format=4 data=0x02
5 input_ubx: data=02
5 input_raw: format=4 data=0x00
5 input_ubx: data=00
5 input_raw: format=4 data=0x06
5 input_ubx: data=06
5 input_raw: format=4 data=0x71
5 input_ubx: data=71
5 input_raw: format=4 data=0x7f
5 input_ubx: data=7f
5 input_raw: format=4 data=0xa8
5 input_ubx: data=a8
3 decode_ubx: type=0501 len=10