### PR TITLE
structure raw_t filed nbyte not reset 0 after message bytes complete

### DIFF
--- a/src/rcv/binex.c
+++ b/src/rcv/binex.c
@@ -1216,6 +1216,11 @@ extern int input_bnx(raw_t *raw, unsigned char data)
     
     trace(5,"input_bnx: data=%02x\n",data);
     
+    /* new message */
+    if (raw->complete) {
+        raw->complete=0;
+        raw->nbyte=0;
+    }
     /* synchronize binex message */
     if (raw->nbyte==0) {
         if (!sync_bnx(raw->buff,data)) return 0;
@@ -1237,7 +1242,7 @@ extern int input_bnx(raw_t *raw, unsigned char data)
     len_c=raw->len-1<128?1:2;
     
     if (raw->nbyte<(int)(raw->len+len_c)) return 0;
-    raw->nbyte=0;
+    raw->complete=1;
     
     /* decode binex message */
     return decode_bnx(raw);
@@ -1255,6 +1260,11 @@ extern int input_bnxf(raw_t *raw, FILE *fp)
     
     trace(4,"input_bnxf\n");
     
+    /* new message */
+    if (raw->complete) {
+        raw->complete=0;
+        raw->nbyte=0;
+    }
     if (raw->nbyte==0) {
         for (i=0;;i++) {
             if ((data=fgetc(fp))==EOF) return -2;
@@ -1278,7 +1288,7 @@ extern int input_bnxf(raw_t *raw, FILE *fp)
     if (fread(raw->buff+6,1,raw->len+len_c-6,fp)<(size_t)(raw->len+len_c-6)) {
         return -2;
     }
-    raw->nbyte=0;
+    raw->complete=1;
     
     /* decode binex message */
     return decode_bnx(raw);

--- a/src/rcv/crescent.c
+++ b/src/rcv/crescent.c
@@ -565,6 +565,11 @@ extern int input_cres(raw_t *raw, unsigned char data)
 {
     trace(5,"input_cres: data=%02x\n",data);
     
+    /* new message */
+    if (raw->complete) {
+        raw->complete=0;
+        raw->nbyte=0;
+    }
     /* synchronize frame */
     if (raw->nbyte==0) {
         if (!sync_cres(raw->buff,data)) return 0;
@@ -581,7 +586,7 @@ extern int input_cres(raw_t *raw, unsigned char data)
         }
     }
     if (raw->nbyte<8||raw->nbyte<raw->len) return 0;
-    raw->nbyte=0;
+    raw->complete=1;
     
     /* decode crescent raw message */
     return decode_cres(raw);
@@ -598,6 +603,11 @@ extern int input_cresf(raw_t *raw, FILE *fp)
     
     trace(4,"input_cresf:\n");
     
+    /* new message */
+    if (raw->complete) {
+        raw->complete=0;
+        raw->nbyte=0;
+    }
     /* synchronize frame */
     if (raw->nbyte==0) {
         for (i=0;;i++) {
@@ -615,7 +625,7 @@ extern int input_cresf(raw_t *raw, FILE *fp)
         return -1;
     }
     if (fread(raw->buff+8,1,raw->len-8,fp)<(size_t)(raw->len-8)) return -2;
-    raw->nbyte=0;
+    raw->complete=1;
     
     /* decode crescent raw message */
     return decode_cres(raw);

--- a/src/rcv/gw10.c
+++ b/src/rcv/gw10.c
@@ -377,6 +377,13 @@ extern int input_gw10(raw_t *raw, unsigned char data)
     int stat;
     trace(5,"input_gw10: data=%02x\n",data);
     
+    /* new message */
+    if (raw->complete) {
+        raw->complete=0;
+        raw->nbyte=0;
+        raw->buff[0]=0;
+    }
+
     raw->buff[raw->nbyte++]=data;
     
     /* synchronize frame */
@@ -399,8 +406,7 @@ extern int input_gw10(raw_t *raw, unsigned char data)
     /* decode gw10 raw message */
     stat=decode_gw10(raw);
     
-    raw->buff[0]=0;
-    raw->nbyte=0;
+    raw->complete=1;
     
     return stat;
 }

--- a/src/rcv/javad.c
+++ b/src/rcv/javad.c
@@ -1772,6 +1772,12 @@ extern int input_javad(raw_t *raw, unsigned char data)
     
     trace(5,"input_javad: data=%02x\n",data);
     
+    /* new message */
+    if (raw->complete) {
+        raw->complete=0;
+        clearbuff(raw);
+    }
+
     /* synchronize message */
     if (raw->nbyte==0) {
         if (!sync_javad(raw->buff,data)) return 0;
@@ -1791,7 +1797,7 @@ extern int input_javad(raw_t *raw, unsigned char data)
     /* decode javad raw message */
     stat=decode_javad(raw);
     
-    clearbuff(raw);
+    raw->complete=1;
     return stat;
 }
 /* start input file ----------------------------------------------------------*/
@@ -1826,6 +1832,13 @@ extern int input_javadf(raw_t *raw, FILE *fp)
         startfile(raw);
         raw->flag=0;
     }
+
+    /* new message */
+    if (raw->complete) {
+        raw->complete=0;
+        clearbuff(raw);
+    }
+
     /* synchronize message */
     if (raw->nbyte==0) {
         for (i=0;;i++) {
@@ -1848,6 +1861,6 @@ extern int input_javadf(raw_t *raw, FILE *fp)
     /* decode javad raw message */
     stat=decode_javad(raw);
     
-    clearbuff(raw);
+    raw->complete=1;
     return stat;
 }

--- a/src/rcv/novatel.c
+++ b/src/rcv/novatel.c
@@ -1396,6 +1396,11 @@ extern int input_oem4(raw_t *raw, unsigned char data)
 {
     trace(5,"input_oem4: data=%02x\n",data);
     
+    /* new message */
+    if (raw->complete) {
+        raw->complete=0;
+        raw->nbyte=0;
+    }
     /* synchronize frame */
     if (raw->nbyte==0) {
         if (sync_oem4(raw->buff,data)) raw->nbyte=3;
@@ -1409,7 +1414,7 @@ extern int input_oem4(raw_t *raw, unsigned char data)
         return -1;
     }
     if (raw->nbyte<10||raw->nbyte<raw->len+4) return 0;
-    raw->nbyte=0;
+    raw->complete=1;
     
     /* decode oem4 message */
     return decode_oem4(raw);
@@ -1418,6 +1423,11 @@ extern int input_oem3(raw_t *raw, unsigned char data)
 {
     trace(5,"input_oem3: data=%02x\n",data);
     
+    /* new message */
+    if (raw->complete) {
+        raw->complete=0;
+        raw->nbyte=0;
+    }
     /* synchronize frame */
     if (raw->nbyte==0) {
         if (sync_oem3(raw->buff,data)) raw->nbyte=3;
@@ -1431,7 +1441,7 @@ extern int input_oem3(raw_t *raw, unsigned char data)
         return -1;
     }
     if (raw->nbyte<12||raw->nbyte<raw->len) return 0;
-    raw->nbyte=0;
+    raw->complete=1;
     
     /* decode oem3 message */
     return decode_oem3(raw);
@@ -1449,6 +1459,11 @@ extern int input_oem4f(raw_t *raw, FILE *fp)
     
     trace(4,"input_oem4f:\n");
     
+    /* new message */
+    if (raw->complete) {
+        raw->complete=0;
+        raw->nbyte=0;
+    }
     /* synchronize frame */
     if (raw->nbyte==0) {
         for (i=0;;i++) {
@@ -1466,7 +1481,7 @@ extern int input_oem4f(raw_t *raw, FILE *fp)
         return -1;
     }
     if (fread(raw->buff+10,raw->len-6,1,fp)<1) return -2;
-    raw->nbyte=0;
+    raw->complete=1;
     
     /* decode oem4 message */
     return decode_oem4(raw);
@@ -1477,6 +1492,11 @@ extern int input_oem3f(raw_t *raw, FILE *fp)
     
     trace(4,"input_oem3f:\n");
     
+    /* new message */
+    if (raw->complete) {
+        raw->complete=0;
+        raw->nbyte=0;
+    }
     /* synchronize frame */
     if (raw->nbyte==0) {
         for (i=0;;i++) {
@@ -1494,7 +1514,7 @@ extern int input_oem3f(raw_t *raw, FILE *fp)
         return -1;
     }
     if (fread(raw->buff+12,1,raw->len-12,fp)<(size_t)(raw->len-12)) return -2;
-    raw->nbyte=0;
+    raw->complete=1;
     
     /* decode oem3 message */
     return decode_oem3(raw);

--- a/src/rcv/septentrio.c
+++ b/src/rcv/septentrio.c
@@ -2203,6 +2203,12 @@ extern int input_sbf(raw_t *raw, unsigned char data)
 {
     trace(5,"input_sbf: data=%02x\n",data);
 
+    /* new message */
+    if (raw->complete) {
+        raw->complete=0;
+        raw->nbyte=0;
+    }
+
     if (raw->nbyte==0) {
         if (sync_sbf(raw->buff,data)) raw->nbyte=2;
         return 0;
@@ -2217,7 +2223,7 @@ extern int input_sbf(raw_t *raw, unsigned char data)
         return -1;
     }
     if (raw->nbyte<raw->len) return 0;
-    raw->nbyte=0;
+    raw->complete=1;
 
     return decode_sbf(raw);
 }
@@ -2232,6 +2238,12 @@ extern int input_sbff(raw_t *raw, FILE *fp)
     int i,data;
 
     trace(4,"input_sbff:\n");
+
+    /* new message */
+    if (raw->complete) {
+        raw->complete=0;
+        raw->nbyte=0;
+    }
 
     /* go to the beginning of the first block */
     if (raw->nbyte==0) {
@@ -2257,7 +2269,7 @@ extern int input_sbff(raw_t *raw, FILE *fp)
     /* let's store in raw->buff the whole block of length len */
     /* 8 bytes have been already read, we read raw->len-8 more */
     if (fread(raw->buff+8,1,raw->len-8,fp)<(size_t)(raw->len-8)) return -2;
-    raw->nbyte=0;           /* this indicates where we point inside raw->buff */
+    raw->complete=1;           /* this indicates where we point inside raw->buff */
 
     /* decode SBF block */
     return decode_sbf(raw);

--- a/src/rcv/skytraq.c
+++ b/src/rcv/skytraq.c
@@ -690,6 +690,12 @@ extern int input_stq(raw_t *raw, unsigned char data)
 {
     trace(5,"input_stq: data=%02x\n",data);
     
+    /* new message */
+    if (raw->complete) {
+        raw->complete=0;
+        raw->nbyte=0;
+    }
+
     /* synchronize frame */
     if (raw->nbyte==0) {
         if (!sync_stq(raw->buff,data)) return 0;
@@ -706,7 +712,7 @@ extern int input_stq(raw_t *raw, unsigned char data)
         }
     }
     if (raw->nbyte<4||raw->nbyte<raw->len) return 0;
-    raw->nbyte=0;
+    raw->complete=1;
     
     /* decode skytraq raw message */
     return decode_stq(raw);
@@ -722,7 +728,13 @@ extern int input_stqf(raw_t *raw, FILE *fp)
     int i,data;
     
     trace(4,"input_stqf:\n");
-    
+
+    /* new message */
+    if (raw->complete) {
+        raw->complete=0;
+        raw->nbyte=0;
+    }
+
     /* synchronize frame */
     if (raw->nbyte==0) {
         for (i=0;;i++) {
@@ -740,7 +752,7 @@ extern int input_stqf(raw_t *raw, FILE *fp)
         return -1;
     }
     if (fread(raw->buff+4,1,raw->len-4,fp)<(size_t)(raw->len-4)) return -2;
-    raw->nbyte=0;
+    raw->complete=1;
     
     /* decode skytraq raw message */
     return decode_stq(raw);

--- a/src/rcv/ss2.c
+++ b/src/rcv/ss2.c
@@ -255,6 +255,12 @@ extern int input_ss2(raw_t *raw, unsigned char data)
 {
     trace(5,"input_ss2: data=%02x\n",data);
     
+    /* new message */
+    if (raw->complete) {
+        raw->complete=0;
+        raw->nbyte=0;
+    }
+
     /* synchronize frame */
     if (raw->nbyte==0) {
         if (!sync_ss2(raw->buff,data)) return 0;
@@ -271,7 +277,7 @@ extern int input_ss2(raw_t *raw, unsigned char data)
         }
     }
     if (raw->nbyte<4||raw->nbyte<raw->len) return 0;
-    raw->nbyte=0;
+    raw->complete=1;
     
     /* decode superstar 2 raw message */
     return decode_ss2(raw);
@@ -288,6 +294,11 @@ extern int input_ss2f(raw_t *raw, FILE *fp)
     
     trace(4,"input_ss2f:\n");
     
+    /* new message */
+    if (raw->complete) {
+        raw->complete=0;
+        raw->nbyte=0;
+    }
     /* synchronize frame */
     if (raw->nbyte==0) {
         for (i=0;;i++) {
@@ -305,7 +316,7 @@ extern int input_ss2f(raw_t *raw, FILE *fp)
         return -1;
     }
     if (fread(raw->buff+4,1,raw->len-4,fp)<(size_t)(raw->len-4)) return -2;
-    raw->nbyte=0;
+    raw->complete=1;
     
     /* decode superstar 2 raw message */
     return decode_ss2(raw);

--- a/src/rcv/tersus.c
+++ b/src/rcv/tersus.c
@@ -657,6 +657,12 @@ extern int input_tersus(raw_t *raw, unsigned char data)
 {
     trace(5,"input_tersus: data=%02x\n",data);
     
+    /* new message */
+    if (raw->complete) {
+        raw->complete=0;
+        raw->nbyte=0;
+    }
+
     /* synchronize frame */
     if (raw->nbyte==0) {
         if (sync_tersus(raw->buff,data)) raw->nbyte=3;
@@ -670,7 +676,7 @@ extern int input_tersus(raw_t *raw, unsigned char data)
         return -1;
     }
     if (raw->nbyte<10||raw->nbyte<raw->len+4) return 0;
-    raw->nbyte=0;
+    raw->complete=1;
     
     /* decode tersus message */
     return decode_tersus(raw);
@@ -688,6 +694,12 @@ extern int input_tersusf(raw_t *raw, FILE *fp)
     
     trace(4,"input_tersusf:\n");
     
+    /* new message */
+    if (raw->complete) {
+        raw->complete=0;
+        raw->nbyte=0;
+    }
+
     /* synchronize frame */
     if (raw->nbyte==0) {
         for (i=0;;i++) {
@@ -705,7 +717,7 @@ extern int input_tersusf(raw_t *raw, FILE *fp)
         return -1;
     }
     if (fread(raw->buff+10,raw->len-6,1,fp)<1) return -2;
-    raw->nbyte=0;
+    raw->complete=1;
     
     /* decode tersus message */
     return decode_tersus(raw);

--- a/src/rcv/ublox.c
+++ b/src/rcv/ublox.c
@@ -1084,6 +1084,11 @@ extern int input_ubx(raw_t *raw, unsigned char data)
 {
     trace(5,"input_ubx: data=%02x\n",data);
     
+    /* new message */
+    if (raw->complete) {
+        raw->complete=0;
+        raw->nbyte=0;
+    }
     /* synchronize frame */
     if (raw->nbyte==0) {
         if (!sync_ubx(raw->buff,data)) return 0;
@@ -1100,7 +1105,7 @@ extern int input_ubx(raw_t *raw, unsigned char data)
         }
     }
     if (raw->nbyte<6||raw->nbyte<raw->len) return 0;
-    raw->nbyte=0;
+    raw->complete=1;
     
     /* decode ublox raw message */
     return decode_ubx(raw);

--- a/src/rcvraw.c
+++ b/src/rcvraw.c
@@ -882,6 +882,7 @@ extern int init_raw(raw_t *raw, int format)
     raw->lexmsg=lexmsg0;
     raw->icpc=0.0;
     raw->nbyte=raw->len=0;
+    raw->complete=0;
     raw->iod=raw->flag=raw->tbase=raw->outtype=0;
     raw->tod=-1;
     for (i=0;i<MAXRAWLEN;i++) raw->buff[i]=0;

--- a/src/rtklib.h
+++ b/src/rtklib.h
@@ -1252,6 +1252,8 @@ typedef struct {        /* receiver raw data control type */
     
     int format;         /* receiver stream format */
     void *rcv_data;     /* receiver dependent data */
+
+    int complete;       /* if message bytes complete in buffer */
 } raw_t;
 
 typedef struct {        /* stream type */


### PR DESCRIPTION
This is a feature improvement.
This is usefull for using `raw_t` to decode raw data but also want to fetch origin bytes  including checksum parts(if have).

The approach is, adding a new field `complete`(BOOL/int) to structure `raw_t` ,  indicating if message bytes complete. User can use filed `nbyte` to fetch all message bytes include checksum bytes after
input_raw return positive number.

I have test this for binex message decoding.