### PR TITLE
Corrections in processing of Galileo Nav Messages

### DIFF
--- a/app/convbin/convbin.c
+++ b/app/convbin/convbin.c
@@ -37,6 +37,8 @@ static const char rcsid[]="$Id: convbin.c,v 1.1 2008/07/17 22:13:04 ttaka Exp $"
 #define PRGNAME   "CONVBIN"
 #define TRACEFILE "convbin.trace"
 
+int galmessagetype;
+
 /* help text -----------------------------------------------------------------*/
 static const char *help[]={
 "",
@@ -165,6 +167,8 @@ static int convbin(int format, rnxopt_t *opt, const char *ifile, char **file,
     char *extnav=opt->rnxver<=2.99||opt->navsys==SYS_GPS?"N":"P";
     char *extlog=format==STRFMT_LEXR?"lex":"sbs";
     
+    galmessagetype = GALMESS_INAV;
+
     def=!file[0]&&!file[1]&&!file[2]&&!file[3]&&!file[4]&&!file[5]&&!file[6];
     
     for (i=0;i<7;i++) ofile[i]=ofile_[i];

--- a/app/rnx2rtkp/rnx2rtkp.c
+++ b/app/rnx2rtkp/rnx2rtkp.c
@@ -22,6 +22,8 @@ static const char rcsid[]="$Id: rnx2rtkp.c,v 1.1 2008/07/17 21:55:16 ttaka Exp $
 #define PROGNAME    "rnx2rtkp"          /* program name */
 #define MAXFILE     8                   /* max number of input files */
 
+int galmessagetype;
+
 /* help text -----------------------------------------------------------------*/
 static const char *help[]={
 "",
@@ -97,6 +99,8 @@ int main(int argc, char **argv)
     int i,j,n,ret;
     char *infile[MAXFILE],*outfile="";
     
+    galmessagetype = GALMESS_INAV;
+
     prcopt.mode  =PMODE_KINEMA;
     prcopt.navsys=SYS_GPS|SYS_GLO;
     prcopt.refpos=1;
@@ -162,6 +166,8 @@ int main(int argc, char **argv)
         showmsg("error : no input file");
         return -2;
     }
+
+    if (prcopt.ionoopt==IONOOPT_IFLC) galmessagetype=GALMESS_FNAV;
     ret=postpos(ts,te,tint,0.0,&prcopt,&solopt,&filopt,infile,n,outfile,"","");
     
     if (!ret) fprintf(stderr,"%40s\r","");

--- a/app/rtkrcv/rtkrcv.c
+++ b/app/rtkrcv/rtkrcv.c
@@ -138,6 +138,8 @@ static const char *pathopts[]={         /* path options help */
 #define SOLOPT  "0:llh,1:xyz,2:enu,3:nmea"
 #define MSGOPT  "0:all,1:rover,2:base,3:corr"
 
+int galmessagetype;
+
 static opt_t rcvopts[]={
     {"console-passwd",  2,  (void *)passwd,              ""     },
     {"console-timetype",3,  (void *)&timetype,           TIMOPT },
@@ -1369,6 +1371,8 @@ int main(int argc, char **argv)
     int i,start=0,port=0,outstat=0,trace=0;
     char *dev="",file[MAXSTR]="";
     
+    galmessagetype = GALMESS_INAV;
+
     for (i=1;i<argc;i++) {
         if      (!strcmp(argv[i],"-s")) start=1;
         else if (!strcmp(argv[i],"-p")&&i+1<argc) port=atoi(argv[++i]);

--- a/src/pntpos.c
+++ b/src/pntpos.c
@@ -203,7 +203,9 @@ static int rescode(int iter, const obsd_t *obs, int n, const double *rs,
                    double *resp, int *ns)
 {
     double r,dion,dtrp,vmeas,vion,vtrp,rr[3],pos[3],dtr,e[3],P,lam_L1;
-    int i,j,nv=0,sys,mask[4]={0};
+    int i,j,nv=0,sys,mask[4]={0},sva=-1;
+
+    eph_t *eph;
     
     trace(3,"resprng : n=%d\n",n);
     
@@ -230,8 +232,13 @@ static int rescode(int iter, const obsd_t *obs, int n, const double *rs,
         /* psudorange with code bias correction */
         if ((P=prange(obs+i,nav,azel+i*2,iter,opt,&vmeas))==0.0) continue;
         
+        /* if Gal satellite, check SISA is not NAPA*/
+        if (sys==SYS_GAL){
+        	if (!(eph=seleph(obs[i].time,obs[i].sat,-1,nav))) continue;
+        	sva = eph->sva;
+        }
         /* excluded satellite? */
-        if (satexclude(obs[i].sat,svh[i],opt)) continue;
+        if (satexclude(obs[i].sat,svh[i],sva,opt)) continue;
         
         /* ionospheric corrections */
         if (!ionocorr(obs[i].time,nav,obs[i].sat,pos,azel+i*2,

--- a/src/ppp.c
+++ b/src/ppp.c
@@ -884,7 +884,9 @@ static int res_ppp(int iter, const obsd_t *obs, int n, const double *rs,
     prcopt_t *opt=&rtk->opt;
     double r,rr[3],disp[3],pos[3],e[3],meas[2],dtdx[3],dantr[NFREQ]={0};
     double dants[NFREQ]={0},var[MAXOBS*2],dtrp=0.0,vart=0.0,varm[2]={0};
-    int i,j,k,sat,sys,nv=0,nx=rtk->nx,brk,tideopt;
+    int i,j,k,sat,sys,nv=0,nx=rtk->nx,brk,tideopt,sva=-1;
+
+    eph_t *eph;
     
     trace(3,"res_ppp : n=%d nx=%d\n",n,nx);
     
@@ -910,8 +912,14 @@ static int res_ppp(int iter, const obsd_t *obs, int n, const double *rs,
         if ((r=geodist(rs+i*6,rr,e))<=0.0||
             satazel(pos,e,azel+i*2)<opt->elmin) continue;
         
+        /* if Gal satellite, check SISA is not NAPA*/
+        if (sys==SYS_GAL){
+        	if (!(eph=seleph(obs[i].time,obs[i].sat,-1,nav))) continue;
+        	sva = eph->sva;
+        }
+
         /* excluded satellite? */
-        if (satexclude(obs[i].sat,svh[i],opt)) continue;
+        if (satexclude(obs[i].sat,svh[i],sva,opt)) continue;
         
         /* tropospheric delay correction */
         if (opt->tropopt==TROPOPT_SAAS) {

--- a/src/rtklib.h
+++ b/src/rtklib.h
@@ -137,7 +137,7 @@ extern "C" {
 #endif
 #ifdef ENAGAL
 #define MINPRNGAL   1                   /* min satellite PRN number of Galileo */
-#define MAXPRNGAL   30                  /* max satellite PRN number of Galileo */
+#define MAXPRNGAL   36                  /* max satellite PRN number of Galileo */
 #define NSATGAL    (MAXPRNGAL-MINPRNGAL+1) /* number of Galileo satellites */
 #define NSYSGAL     1
 #else
@@ -199,7 +199,7 @@ extern "C" {
 #define DTTOL       0.005               /* tolerance of time difference (s) */
 #define MAXDTOE     7200.0              /* max time difference to GPS Toe (s) */
 #define MAXDTOE_QZS 7200.0              /* max time difference to QZSS Toe (s) */
-#define MAXDTOE_GAL 10800.0             /* max time difference to Galileo Toe (s) */
+#define MAXDTOE_GAL 14400.0             /* max time difference to Galileo Toe (s) */
 #define MAXDTOE_CMP 21600.0             /* max time difference to BeiDou Toe (s) */
 #define MAXDTOE_GLO 1800.0              /* max time difference to GLONASS Toe (s) */
 #define MAXDTOE_SBS 360.0               /* max time difference to SBAS Toe (s) */
@@ -337,6 +337,9 @@ extern "C" {
 #define IONOOPT_QZS 6                   /* ionosphere option: QZSS broadcast model */
 #define IONOOPT_LEX 7                   /* ionosphere option: QZSS LEX ionospehre */
 #define IONOOPT_STEC 8                  /* ionosphere option: SLANT TEC model */
+
+#define GALMESS_INAV 0                  /* Galileo message type: FNAV */
+#define GALMESS_FNAV 1                  /* Galileo message type: INAV */
 
 #define TROPOPT_OFF 0                   /* troposphere option: correction off */
 #define TROPOPT_SAAS 1                  /* troposphere option: Saastamoinen model */
@@ -1260,6 +1263,7 @@ extern const sbsigpband_t igpband1[][8]; /* SBAS IGP band 0-8 */
 extern const sbsigpband_t igpband2[][5]; /* SBAS IGP band 9-10 */
 extern const char *formatstrs[];        /* stream format strings */
 extern opt_t sysopts[];                 /* system options table */
+extern int galmessagetype;              /* GAL message type */
 
 /* satellites, systems, codes functions --------------------------------------*/
 extern int  satno   (int sys, int prn);
@@ -1268,7 +1272,7 @@ extern int  satid2no(const char *id);
 extern void satno2id(int sat, char *id);
 extern unsigned char obs2code(const char *obs, int *freq);
 extern char *code2obs(unsigned char code, int *freq);
-extern int  satexclude(int sat, int svh, const prcopt_t *opt);
+extern int  satexclude(int sat, int svh, const int sva, const prcopt_t *opt);
 extern int  testsnr(int base, int freq, double el, double snr,
                     const snrmask_t *mask);
 extern void setcodepri(int sys, int freq, const char *pri);
@@ -1491,6 +1495,8 @@ extern int tle_name_read(const char *file, tle_t *tle);
 extern int tle_pos(gtime_t time, const char *name, const char *satno,
                    const char *desig, const tle_t *tle, const erp_t *erp,
                    double *rs);
+extern eph_t *seleph(const gtime_t time, const int sat, const int iode,
+                     const nav_t *nav);
 
 /* receiver raw data functions -----------------------------------------------*/
 extern unsigned int getbitu(const unsigned char *buff, int pos, int len);

--- a/src/rtkpos.c
+++ b/src/rtkpos.c
@@ -851,7 +851,9 @@ static int zdres(int base, const obsd_t *obs, int n, const double *rs,
 {
     double r,rr_[3],pos[3],dant[NFREQ]={0},disp[3];
     double zhd,zazel[]={0.0,90.0*D2R};
-    int i,nf=NF(opt);
+    int i,nf=NF(opt),sys,sva=-1;
+
+    eph_t *eph;
     
     trace(3,"zdres   : n=%d\n",n);
     
@@ -874,8 +876,14 @@ static int zdres(int base, const obsd_t *obs, int n, const double *rs,
         if ((r=geodist(rs+i*6,rr_,e+i*3))<=0.0) continue;
         if (satazel(pos,e+i*3,azel+i*2)<opt->elmin) continue;
         
+        /* if Gal satellite, check SISA is not NAPA*/
+        if (!(sys=satsys(obs[i].sat,NULL))) continue;
+        if (sys==SYS_GAL){
+        	if (!(eph=seleph(obs[i].time,obs[i].sat,-1,nav))) continue;
+        	sva = eph->sva;
+        }
         /* excluded satellite? */
-        if (satexclude(obs[i].sat,svh[i],opt)) continue;
+        if (satexclude(obs[i].sat,svh[i],sva,opt)) continue;
         
         /* satellite clock-bias */
         r+=-CLIGHT*dts[i*2];


### PR DESCRIPTION
A number of improvements have been included to process Galileo Navigation Messages:
-GAL max PRN increased to 36
-New functions implemented to convert SISA indexes to value according to the SIS ICD.
-Position and clock variance for Galileo satellites is now calculated according to the SISA index to value conversion from SIS ICD.
-Selection of ephemeris for Galileo satellites now takes into account the message type (FNAV/INAV) and the frequencies being processed.
-Calculation of t0e has been corrected for Galileo satellites.
-Max t0e for Galileo Navigation messages modified to 4 hours as per the OS SDD.
-Galileo satellites with a Navigation Message with SISA set to NAPA are now excluded from the navigation solution.
Processing of Galileo messages in RINEX navigation messages files is also modified to process the SISA field as described in the SIS ICD. An exception is a SISA of 0.0 m or -1 m, which is interpreted as NAPA due to the non-definition of such value in RINEX files after analyzing the way in which multiple receivers work.
