### PR TITLE
 Add ifdef around B460800 for mac sport.

### DIFF
--- a/src/stream.c
+++ b/src/stream.c
@@ -350,7 +350,10 @@ static serial_t *openserial(const char *path, int mode, char *msg)
 #else
     const speed_t bs[]={
         B300,B600,B1200,B2400,B4800,B9600,B19200,B38400,B57600,B115200,B230400,
+
+        #ifdef B460800
         B460800,B921600
+        #endif
     };
     struct termios ios={0};
     int rw=0;


### PR DESCRIPTION
Mac's dont support the B460800 define,
adding a ifdef around it before including it in the list.

