### PR TITLE
Rename #define lock -> rtk_lock avoid clashing with

### DIFF
--- a/src/rtkcmn.c
+++ b/src/rtkcmn.c
@@ -2860,7 +2860,7 @@ static void traceswap(void)
     gtime_t time=utc2gpst(timeget());
     char path[1024];
     
-    lock(&lock_trace);
+    rtk_lock(&lock_trace);
     
     if ((int)(time2gpst(time      ,NULL)/INT_SWAP_TRAC)==
         (int)(time2gpst(time_trace,NULL)/INT_SWAP_TRAC)) {

--- a/src/rtklib.h
+++ b/src/rtklib.h
@@ -511,14 +511,14 @@ extern "C" {
 #define thread_t    HANDLE
 #define lock_t      CRITICAL_SECTION
 #define initlock(f) InitializeCriticalSection(f)
-#define lock(f)     EnterCriticalSection(f)
+#define rtk_lock(f)     EnterCriticalSection(f)
 #define unlock(f)   LeaveCriticalSection(f)
 #define FILEPATHSEP '\\'
 #else
 #define thread_t    pthread_t
 #define lock_t      pthread_mutex_t
 #define initlock(f) pthread_mutex_init(f,NULL)
-#define lock(f)     pthread_mutex_lock(f)
+#define rtk_lock(f)     pthread_mutex_lock(f)
 #define unlock(f)   pthread_mutex_unlock(f)
 #define FILEPATHSEP '/'
 #endif

--- a/src/rtksvr.c
+++ b/src/rtksvr.c
@@ -753,7 +753,7 @@ extern void rtksvrfree(rtksvr_t *svr)
 * args   : rtksvr_t *svr    IO rtk server
 * return : status (1:ok 0:error)
 *-----------------------------------------------------------------------------*/
-extern void rtksvrlock  (rtksvr_t *svr) {lock  (&svr->lock);}
+extern void rtksvrlock  (rtksvr_t *svr) {rtk_lock  (&svr->lock);}
 extern void rtksvrunlock(rtksvr_t *svr) {unlock(&svr->lock);}
 
 /* start rtk server ------------------------------------------------------------

--- a/src/stream.c
+++ b/src/stream.c
@@ -276,7 +276,7 @@ static int readseribuff(serial_t *serial, unsigned char *buff, int nmax)
     
     tracet(5,"readseribuff: dev=%d\n",serial->dev);
     
-    lock(&serial->lock);
+    rtk_lock(&serial->lock);
     for (ns=0;serial->rp!=serial->wp&&ns<nmax;ns++) {
        buff[ns]=serial->buff[serial->rp];
        if (++serial->rp>=serial->buffsize) serial->rp=0;
@@ -291,7 +291,7 @@ static int writeseribuff(serial_t *serial, unsigned char *buff, int n)
     
     tracet(5,"writeseribuff: dev=%d n=%d\n",serial->dev,n);
     
-    lock(&serial->lock);
+    rtk_lock(&serial->lock);
     for (ns=0;ns<n;ns++) {
         serial->buff[wp=serial->wp]=buff[ns];
         if (++wp>=serial->buffsize) wp=0;
@@ -1816,7 +1816,7 @@ static int test_mntpnt(ntripc_t *ntripc, const char *mntpnt)
 {
     char *p,str[256];
     
-    lock(&ntripc->lock_srctbl);
+    rtk_lock(&ntripc->lock_srctbl);
     
     if (!ntripc->srctbl) {
         unlock(&ntripc->lock_srctbl);
@@ -1835,7 +1835,7 @@ static void send_srctbl(ntripc_t *ntripc, socket_t sock)
     char buff[1024],*p=buff;
     int len;
     
-    lock(&ntripc->lock_srctbl);
+    rtk_lock(&ntripc->lock_srctbl);
     
     len=ntripc->srctbl?strlen(ntripc->srctbl):0;
     p+=sprintf(p,"%s",NTRIP_RSP_SRCTBL);
@@ -2571,7 +2571,7 @@ static int readmembuf(membuf_t *membuf, unsigned char *buff, int n, char *msg)
     
     if (!membuf) return 0;
     
-    lock(&membuf->lock);
+    rtk_lock(&membuf->lock);
     
     for (i=membuf->rp;i!=membuf->wp&&nr<n;i++) {
         if (i>=membuf->bufsize) i=0;
@@ -2590,7 +2590,7 @@ static int writemembuf(membuf_t *membuf, unsigned char *buff, int n, char *msg)
     
     if (!membuf) return 0;
     
-    lock(&membuf->lock);
+    rtk_lock(&membuf->lock);
     
     for (i=0;i<n;i++) {
         membuf->buf[membuf->wp++]=buff[i];
@@ -2863,7 +2863,7 @@ extern void strsync(stream_t *stream1, stream_t *stream2)
 * args   : stream_t *stream I  stream
 * return : none
 *-----------------------------------------------------------------------------*/
-extern void strlock  (stream_t *stream) {lock  (&stream->lock);}
+extern void strlock  (stream_t *stream) {rtk_lock  (&stream->lock);}
 extern void strunlock(stream_t *stream) {unlock(&stream->lock);}
 
 /* read stream -----------------------------------------------------------------
@@ -3147,7 +3147,7 @@ extern int strsetsrctbl(stream_t *stream, const char *file)
     fclose(fp);
     tracet(3,"strsetsrctbl: n=%d\n",n);
     
-    lock(&ntripc->lock_srctbl);
+    rtk_lock(&ntripc->lock_srctbl);
     
     free(ntripc->srctbl);
     ntripc->srctbl=srctbl;

--- a/src/streamsvr.c
+++ b/src/streamsvr.c
@@ -484,7 +484,7 @@ static void *strsvrthread(void *arg)
                     strwrite(svr->stream+i,svr->buff,n);
                 }
             }
-            lock(&svr->lock);
+            rtk_lock(&svr->lock);
             for (i=0;i<n&&svr->npb<svr->buffsize;i++) {
                 svr->pbuf[svr->npb++]=svr->buff[i];
             }
@@ -729,7 +729,7 @@ extern int strsvrpeek(strsvr_t *svr, unsigned char *buff, int nmax)
     
     if (!svr->state) return 0;
     
-    lock(&svr->lock);
+    rtk_lock(&svr->lock);
     n=svr->npb<nmax?svr->npb:nmax;
     if (n>0) {
         memcpy(buff,svr->pbuf,n);


### PR DESCRIPTION
C++ x11 <mutex> uses lock function.
pound defining a definition of lock causes compile to fail.

See
https://en.cppreference.com/w/cpp/thread/mutex