### PR TITLE
fix function readmembuf bug

### DIFF
--- a/src/stream.c
+++ b/src/stream.c
@@ -2574,7 +2574,10 @@ static int readmembuf(membuf_t *membuf, unsigned char *buff, int n, char *msg)
     lock(&membuf->lock);
     
     for (i=membuf->rp;i!=membuf->wp&&nr<n;i++) {
-        if (i>=membuf->bufsize) i=0;
+        if (i>=membuf->bufsize) {
+            i=0;
+            if(i==membuf->wp) break;
+        }
         buff[nr++]=membuf->buf[i];
     }
     membuf->rp=i;


### PR DESCRIPTION
fix function readmembuf bug. for example,if wp=0 and we set i=0, we hope to break this while loop. unfortunately，next execute i++,and for loop will not break. here contain bug.