### PR TITLE
SNR accuracy .25 -> .01

### DIFF
--- a/src/pntpos.c
+++ b/src/pntpos.c
@@ -72,13 +72,13 @@ static double prange(const obsd_t *obs, const nav_t *nav, const double *azel,
     
     /* test snr mask */
     if (iter>0) {
-        if (testsnr(0,i,azel[1],obs->SNR[i]*0.25,&opt->snrmask)) {
+        if (testsnr(0,i,azel[1],obs->SNR[i]*1.0/RTK_SNR_SCALE,&opt->snrmask)) {
             trace(4,"snr mask: %s sat=%2d el=%.1f snr=%.1f\n",
-                  time_str(obs->time,0),obs->sat,azel[1]*R2D,obs->SNR[i]*0.25);
+                  time_str(obs->time,0),obs->sat,azel[1]*R2D,obs->SNR[i]*1.0/RTK_SNR_SCALE);
             return 0.0;
         }
         if (opt->ionoopt==IONOOPT_IFLC) {
-            if (testsnr(0,j,azel[1],obs->SNR[j]*0.25,&opt->snrmask)) return 0.0;
+            if (testsnr(0,j,azel[1],obs->SNR[j]*1.0/RTK_SNR_SCALE,&opt->snrmask)) return 0.0;
         }
     }
     gamma=SQR(lam[j])/SQR(lam[i]); /* f1^2/f2^2 */

--- a/src/ppp.c
+++ b/src/ppp.c
@@ -374,7 +374,7 @@ static void corr_meas(const obsd_t *obs, const nav_t *nav, const double *azel,
     for (i=0;i<NFREQ;i++) {
         L[i]=P[i]=0.0;
         if (lam[i]==0.0||obs->L[i]==0.0||obs->P[i]==0.0) continue;
-        if (testsnr(0,0,azel[1],obs->SNR[i]*0.25,&opt->snrmask)) continue;
+        if (testsnr(0,0,azel[1],obs->SNR[i]*1.0/RTK_SNR_SCALE,&opt->snrmask)) continue;
         
         /* antenna phase center and phase windup correction */
         L[i]=obs->L[i]*lam[i]-dants[i]-dantr[i]-phw*lam[i];

--- a/src/rcv/binex.c
+++ b/src/rcv/binex.c
@@ -1093,7 +1093,7 @@ static unsigned char *decode_bnx_7f_05_obs(raw_t *raw, unsigned char *buff,
             data->P[i]=range[k];
             data->L[i]=wl<=0.0?0.0:phase[k]/wl;
             data->D[i]=dopp[k];
-            data->SNR[i]=(unsigned char)(cnr[k]/0.25+0.5);
+            data->SNR[i]=(unsigned short)(cnr[k]*RTK_SNR_SCALE+0.5);
             data->code[i]=codes[code[k]&0x3F];
             data->LLI[i]=slip[k]?1:0;
             mask[k]=1;
@@ -1118,7 +1118,7 @@ static unsigned char *decode_bnx_7f_05_obs(raw_t *raw, unsigned char *buff,
             data->P[i]=range[k];
             data->L[i]=wl<=0.0?0.0:phase[k]/wl;
             data->D[i]=dopp[k];
-            data->SNR[i]=(unsigned char)(cnr[k]/0.25+0.5);
+            data->SNR[i]=(unsigned short)(cnr[k]*RTK_SNR_SCALE+0.5);
             data->code[i]=codes[code[k]&0x3F];
             data->LLI[i]=slip[k]?1:0;
             mask[k]=1;

--- a/src/rcv/cmr.c
+++ b/src/rcv/cmr.c
@@ -361,7 +361,7 @@
 #define MAXTIMEDIFF             60.0 /* Maximum tolerable time difference in seconds */
 
 /* Utility macros: */
-#define SNRATIO(snr) (unsigned char)((snr<=0.0)||(snr>=255.5))?(0.0):((snr*4.0)+0.5)
+#define SNRATIO(snr) (unsigned char)((snr<=0.0)||(snr>=255.5))?(0.0):((snr*RTK_SNR_SCALE)+0.5)
 
 /*
 | Typedefs:
@@ -389,9 +389,9 @@ typedef struct {                    /* Base observables data record */
     unsigned int  Slot;             /* Slot number */ 
     unsigned char Sat;              /* Satellite number */
     unsigned char Code[2];          /* L1/L2 code indicators (CODE_???) */
-    unsigned char SNR[2];           /* L1/L2 signal strengths */
     unsigned char Slip[2];          /* L1/L2 slip counts */
     unsigned char LLI[2];           /* L1/L2 loss of lock indicators */
+    unsigned short SNR[2];           /* L1/L2 signal strengths */
 } obsbd_t;
 
 typedef struct {                    /* Base observables header record */
@@ -1326,11 +1326,24 @@ static const rcv_t ReceiversTable[] = {
 | Signal to noise ratio conversion for CMR type 3 (GLONASS) observables.
 | See reference #3.
 */
-static const unsigned char SnrTable[][2] =
-    {{0,0},  {30,4},   {32,8}, {34,12},
-    {36,16}, {38,20}, {40,24}, {42,28},
-    {44,32}, {46,36}, {48,40}, {50,44},
-    {52,48}, {54,52}, {56,56}, {58,60}
+static const unsigned short SnrTable[][2] =
+    {
+    {0 *RTK_SNR_SCALE/4.0,0 *RTK_SNR_SCALE/4.0},  
+    {30*RTK_SNR_SCALE/4.0,4 *RTK_SNR_SCALE/4.0},   
+    {32*RTK_SNR_SCALE/4.0,8 *RTK_SNR_SCALE/4.0}, 
+    {34*RTK_SNR_SCALE/4.0,12*RTK_SNR_SCALE/4.0},
+    {36*RTK_SNR_SCALE/4.0,16*RTK_SNR_SCALE/4.0}, 
+    {38*RTK_SNR_SCALE/4.0,20*RTK_SNR_SCALE/4.0}, 
+    {40*RTK_SNR_SCALE/4.0,24*RTK_SNR_SCALE/4.0}, 
+    {42*RTK_SNR_SCALE/4.0,28*RTK_SNR_SCALE/4.0},
+    {44*RTK_SNR_SCALE/4.0,32*RTK_SNR_SCALE/4.0}, 
+    {46*RTK_SNR_SCALE/4.0,36*RTK_SNR_SCALE/4.0}, 
+    {48*RTK_SNR_SCALE/4.0,40*RTK_SNR_SCALE/4.0}, 
+    {50*RTK_SNR_SCALE/4.0,44*RTK_SNR_SCALE/4.0},
+    {52*RTK_SNR_SCALE/4.0,48*RTK_SNR_SCALE/4.0}, 
+    {54*RTK_SNR_SCALE/4.0,52*RTK_SNR_SCALE/4.0}, 
+    {56*RTK_SNR_SCALE/4.0,56*RTK_SNR_SCALE/4.0}, 
+    {58*RTK_SNR_SCALE/4.0,60*RTK_SNR_SCALE/4.0}
 };
 
 /*

--- a/src/rcv/crescent.c
+++ b/src/rcv/crescent.c
@@ -141,7 +141,7 @@ static int decode_cresraw(raw_t *raw)
         raw->obs.data[n].P[0]=pr;
         raw->obs.data[n].L[0]=cp/lam_carr[0];
         raw->obs.data[n].D[0]=-(float)(dop/lam_carr[0]);
-        raw->obs.data[n].SNR[0]=(unsigned char)(snr*4.0+0.5);
+        raw->obs.data[n].SNR[0]=(unsigned short)(snr*RTK_SNR_SCALE+0.5);
         raw->obs.data[n].LLI[0]=(unsigned char)lli;
         raw->obs.data[n].code[0]=CODE_L1C;
         
@@ -251,7 +251,7 @@ static int decode_cresraw2(raw_t *raw)
                 raw->obs.data[n].P[j]=pr[j]==0.0?0.0:pr[j]-toff;
                 raw->obs.data[n].L[j]=cp[j]==0.0?0.0:cp[j]-toff/lam_carr[j];
                 raw->obs.data[n].D[j]=-(float)dop[j];
-                raw->obs.data[n].SNR[j]=(unsigned char)(snr[j]*4.0+0.5);
+                raw->obs.data[n].SNR[j]=(unsigned char)(snr[j]*RTK_SNR_SCALE+0.5);
                 raw->obs.data[n].LLI[j]=(unsigned char)lli[j];
                 raw->obs.data[n].code[j]=j==0?CODE_L1C:CODE_L2P;
             }
@@ -453,7 +453,7 @@ static int decode_cresgloraw(raw_t *raw)
                 raw->obs.data[n].P[j]=pr[j]==0.0?0.0:pr[j]-toff;
                 raw->obs.data[n].L[j]=cp[j]==0.0?0.0:cp[j]-toff/lam_carr[j];
                 raw->obs.data[n].D[j]=-(float)dop[j];
-                raw->obs.data[n].SNR[j]=(unsigned char)(snr[j]*4.0+0.5);
+                raw->obs.data[n].SNR[j]=(unsigned short)(snr[j]*RTK_SNR_SCALE+0.5);
                 raw->obs.data[n].LLI[j]=(unsigned char)lli[j];
                 raw->obs.data[n].code[j]=j==0?CODE_L1C:CODE_L2P;
             }

--- a/src/rcv/gw10.c
+++ b/src/rcv/gw10.c
@@ -153,7 +153,7 @@ static int decode_gw10raw(raw_t *raw)
         raw->obs.data[n].P[0]=pr;
         raw->obs.data[n].L[0]=(flg&0x80)?0.0:((flg&0x40)?cp-0.5:cp);
         raw->obs.data[n].D[0]=0.0;
-        raw->obs.data[n].SNR[0]=(unsigned char)(snr*4.0+0.5);
+        raw->obs.data[n].SNR[0]=(unsigned short)(snr*RTK_SNR_SCALE+0.5);
         raw->obs.data[n].LLI[0]=(flg&0x80)?1:0;
         raw->obs.data[n].code[0]=CODE_L1C;
         

--- a/src/rcv/javad.c
+++ b/src/rcv/javad.c
@@ -1562,7 +1562,7 @@ static int decode_Ex(raw_t *raw, char code)
         
         if ((j=checkpri(raw->opt,sys,type,freq))>=0) {
             if (!settag(raw->obuf.data+i,raw->time)) continue;
-            raw->obuf.data[i].SNR[j]=(unsigned char)(cnr*4.0+0.5);
+            raw->obuf.data[i].SNR[j]=(unsigned short)(cnr*RTK_SNR_SCALE+0.5);
         }
     }
     return 0;

--- a/src/rcv/novatel.c
+++ b/src/rcv/novatel.c
@@ -371,7 +371,7 @@ static int decode_rangecmpb(raw_t *raw)
             raw->obs.data[index].P  [pos]=psr;
             raw->obs.data[index].D  [pos]=(float)dop;
             raw->obs.data[index].SNR[pos]=
-                0.0<=snr&&snr<255.0?(unsigned char)(snr*4.0+0.5):0;
+                0.0<=snr&&snr<255.0?(unsigned short)(snr*RTK_SNR_SCALE+0.5):0;
             raw->obs.data[index].LLI[pos]=(unsigned char)lli;
             raw->obs.data[index].code[pos]=code;
 #if 0
@@ -459,7 +459,7 @@ static int decode_rangeb(raw_t *raw)
             raw->obs.data[index].P  [pos]=psr;
             raw->obs.data[index].D  [pos]=(float)dop;
             raw->obs.data[index].SNR[pos]=
-                0.0<=snr&&snr<255.0?(unsigned char)(snr*4.0+0.5):0;
+                0.0<=snr&&snr<255.0?(unsigned short)(snr*RTK_SNR_SCALE+0.5):0;
             raw->obs.data[index].LLI[pos]=(unsigned char)lli;
             raw->obs.data[index].code[pos]=code;
 #if 0
@@ -1131,7 +1131,7 @@ static int decode_rgeb(raw_t *raw)
             raw->obs.data[index].P  [freq]=psr;
             raw->obs.data[index].D  [freq]=(float)dop;
             raw->obs.data[index].SNR[freq]=
-                0.0<=snr&&snr<255.0?(unsigned char)(snr*4.0+0.5):0;
+                0.0<=snr&&snr<255.0?(unsigned short)(snr*RTK_SNR_SCALE+0.5):0;
             raw->obs.data[index].LLI[freq]=(unsigned char)lli;
             raw->obs.data[index].code[freq]=freq==0?CODE_L1C:CODE_L2P;
         }
@@ -1198,7 +1198,7 @@ static int decode_rged(raw_t *raw)
             raw->obs.data[index].L  [freq]=adr;
             raw->obs.data[index].P  [freq]=psr;
             raw->obs.data[index].D  [freq]=(float)dop;
-            raw->obs.data[index].SNR[freq]=(unsigned char)(snr*4.0+0.5);
+            raw->obs.data[index].SNR[freq]=(unsigned char)(snr*RTK_SNR_SCALE+0.5);
             raw->obs.data[index].LLI[freq]=(unsigned char)lli;
             raw->obs.data[index].code[freq]=freq==0?CODE_L1C:CODE_L2P;
         }

--- a/src/rcv/nvs.c
+++ b/src/rcv/nvs.c
@@ -142,7 +142,7 @@ static int decode_xf5raw(raw_t *raw)
                   sat,L1,P1,D1);
             continue;
         }
-        raw->obs.data[n].SNR[0]=(unsigned char)(I1(p+3)*4.0+0.5);
+        raw->obs.data[n].SNR[0]=(unsigned short)(I1(p+3)*RTK_SNR_SCALE+0.5);
         if (sys==SYS_GLO) {
             raw->obs.data[n].L[0]  =  L1 - toff*(FREQ1_GLO+DFRQ1_GLO*carrNo);
         } else {
@@ -160,7 +160,7 @@ static int decode_xf5raw(raw_t *raw)
         if (raw->obs.data[n].SNR[0] > 160) {
             time2str(time,tstr,3);
             trace(2,"%s, obs.data[%d]: SNR=%.3f  LLI=0x%02x\n",  tstr,
-                n, (raw->obs.data[n].SNR[0])/4.0, U1(p+28) );
+                n, (raw->obs.data[n].SNR[0])/RTK_SNR_SCALE, U1(p+28) );
         }
 #endif
         raw->obs.data[n].code[0] = CODE_L1C;

--- a/src/rcv/rcvlex.c
+++ b/src/rcv/rcvlex.c
@@ -111,7 +111,7 @@ static int decode_lexraw(raw_t *raw)
         
         if (raw->lexmsg.prn==prn) {
             raw->lexmsg.stat=stat;
-            raw->lexmsg.snr=(unsigned char)(cn0*0.04+0.5);
+            raw->lexmsg.snr=(unsigned short)(cn0*0.04+0.5);
             raw->lexmsg.ttt=ttt;
         }
         trace(4,"satid=%3d nsig=%d type=0x%02X node=%d prn=%3d stat=%d\n",
@@ -146,7 +146,7 @@ static int decode_lexraw(raw_t *raw)
             raw->obs.data[n].P[3]=pr;
             raw->obs.data[n].L[3]=adr;
             raw->obs.data[n].D[3]=dop;
-            raw->obs.data[n].SNR[3]=(unsigned char)(cn0*0.04+0.5);
+            raw->obs.data[n].SNR[3]=(unsigned short)(cn0*0.04+0.5);
             raw->obs.data[n].LLI[3]=lli;
             raw->obs.data[n].code[3]=
                 type==0x1A?CODE_L6S:(type==0x1B?CODE_L6L:CODE_NONE);

--- a/src/rcv/rt17.c
+++ b/src/rcv/rt17.c
@@ -1778,7 +1778,7 @@ static int DecodeType17(raw_t *Raw, unsigned int rif)
             if (Flags1 & M_BIT6) /* L1 data valid */
             {           
                 /* Measure of satellite signal strength (dB) */
-                obs->SNR[0] = R8(p) * 4.0;
+                obs->SNR[0] = R8(p) * RTK_SNR_SCALE;
                 p += 8;
 
                 /* Full L1 C/A code or P-code pseudorange (meters) */
@@ -1801,7 +1801,7 @@ static int DecodeType17(raw_t *Raw, unsigned int rif)
             if (Flags1 & M_BIT0) /* L2 data loaded */
             {
                 /* Measure of L2 signal strength (dB) */
-                obs->SNR[1] = R8(p) * 4.0;
+                obs->SNR[1] = R8(p) * RTK_SNR_SCALE;
                 p += 8;
 
                 /* L2 Continuous Phase (cycles) */                

--- a/src/rcv/septentrio.c
+++ b/src/rcv/septentrio.c
@@ -292,9 +292,9 @@ static int decode_measepoch(raw_t *raw){
 
         /* signal to noise ratio in dBHz */
         if ((signType1==1) || (signType1==2)){
-            SNR_DBHZ=((double)U1(p+15))*0.25;
+            SNR_DBHZ=((double)U1(p+15))*(1.0/RTK_SNR_SCALE);
         }
-        else SNR_DBHZ=(((double)U1(p+15))*0.25)+10;
+        else SNR_DBHZ=(((double)U1(p+15))*(1.0/RTK_SNR_SCALE))+10;
 
         /* Compute the carrier phase measurement (a little complicated) */
         LockTime = U2(p+16);             /* Duration of contin. carrier phase */
@@ -380,7 +380,7 @@ static int decode_measepoch(raw_t *raw){
             raw->obs.data[n].L[j]=0.0;
             raw->obs.data[n].P[j]=0.0;
             raw->obs.data[n].D[j]=(float)0.0;
-            raw->obs.data[n].SNR[j]=(unsigned char)0;
+            raw->obs.data[n].SNR[j]=(unsigned short)0;
             raw->obs.data[n].LLI[j]=(unsigned char)0;
             raw->obs.data[n].code[j]=CODE_NONE;            
         }
@@ -402,7 +402,7 @@ static int decode_measepoch(raw_t *raw){
             raw->obs.data[n].L[h]    = adr;
             raw->obs.data[n].P[h]    = psr;
             raw->obs.data[n].D[h]    = (float)dopplerType1;
-            raw->obs.data[n].SNR[h]  = (unsigned char)(SNR_DBHZ*4.0);
+            raw->obs.data[n].SNR[h]  = (unsigned short)(SNR_DBHZ*RTK_SNR_SCALE);
             raw->obs.data[n].code[h] = code;
 
             /* lock to signal indication */
@@ -427,9 +427,9 @@ static int decode_measepoch(raw_t *raw){
 
             /* Signal to noise ratio in dbHz */
             if ((signType2==1) || (signType2==2)){
-                SNR2_DBHZ=((double)U1(p+2))*0.25;
+                SNR2_DBHZ=((double)U1(p+2))*(1.0/RTK_SNR_SCALE);
             }
-            else SNR2_DBHZ=(((double)U1(p+2))*0.25)+10;
+            else SNR2_DBHZ=(((double)U1(p+2))*(1.0/RTK_SNR_SCALE))+10;
 
             offsetMSB = U1(p+3);
             CodeOffsetMSB=((offsetMSB&0x04)==0x04)?offsetMSB| ~((int32_t)0x03):offsetMSB&0x03;                 /* bit[0-2] */
@@ -484,7 +484,7 @@ static int decode_measepoch(raw_t *raw){
                 raw->obs.data[n].L[h]    = Ltype2;
                 raw->obs.data[n].P[h]    = PRtype2;
                 raw->obs.data[n].D[h]    = (float)dopplerType2;
-                raw->obs.data[n].SNR[h]  = (unsigned char)(SNR2_DBHZ*4.0);
+                raw->obs.data[n].SNR[h]  = (unsigned short)(SNR2_DBHZ*RTK_SNR_SCALE);
                 raw->obs.data[n].code[h] = getSignalCode(signType2);
 
                 /* lock to signal indication */

--- a/src/rcv/skytraq.c
+++ b/src/rcv/skytraq.c
@@ -195,7 +195,7 @@ static int decode_stqraw(raw_t *raw)
         raw->obs.data[n].P[0]=pr1;
         raw->obs.data[n].L[0]=cp1;
         raw->obs.data[n].D[0]=!(ind&2)?0.0:R4(p+18);
-        raw->obs.data[n].SNR[0]=U1(p+1)*4;
+        raw->obs.data[n].SNR[0]=U1(p+1)*RTK_SNR_SCALE;
         raw->obs.data[n].LLI[0]=0;
         raw->obs.data[n].code[0]=sys==SYS_CMP?CODE_L1I:CODE_L1C;
         
@@ -324,7 +324,7 @@ static int decode_stqrawx(raw_t *raw)
         raw->obs.data[n].P[0]=pr1;
         raw->obs.data[n].L[0]=cp1;
         raw->obs.data[n].D[0]=!(ind&2)?0.0:R4(p+20);
-        raw->obs.data[n].SNR[0]=U1(p+3)*4;
+        raw->obs.data[n].SNR[0]=U1(p+3)*RTK_SNR_SCALE;
         raw->obs.data[n].LLI[0]=0;
         raw->obs.data[n].code[0]=sys==SYS_CMP?CODE_L1I:CODE_L1C;
         

--- a/src/rcv/ss2.c
+++ b/src/rcv/ss2.c
@@ -128,7 +128,7 @@ static int decode_ss2meas(raw_t *raw)
         raw->icpp[sat-1]=icp;
         raw->obs.data[n].L[0]=icp+raw->icpc;
         raw->obs.data[n].D[0]=0.0;
-        raw->obs.data[n].SNR[0]=(unsigned char)(floor(U1(p+1)+0.5));
+        raw->obs.data[n].SNR[0]=(unsigned short)(floor(U1(p+1)+0.5)*RTK_SNR_SCALE/4.0);
         sc=U1(p+10);
         raw->obs.data[n].LLI[0]=(int)((unsigned char)sc-(unsigned char)raw->lockt[sat-1][0])>0;
         raw->obs.data[n].LLI[0]|=U1(p+6)&1?2:0;

--- a/src/rcv/tersus.c
+++ b/src/rcv/tersus.c
@@ -274,7 +274,7 @@ static int decode_rangeb(raw_t *raw)
             raw->obs.data[index].P  [pos]=psr;
             raw->obs.data[index].D  [pos]=(float)dop;
             raw->obs.data[index].SNR[pos]=
-                0.0<=snr&&snr<255.0?(unsigned char)(snr*4.0+0.5):0;
+                0.0<=snr&&snr<255.0?(unsigned short)(snr*RTK_SNR_SCALE+0.5):0;
             raw->obs.data[index].LLI[pos]=(unsigned char)lli;
             raw->obs.data[index].code[pos]=code;
         }
@@ -359,7 +359,7 @@ static int decode_rangecmpb(raw_t *raw)
             raw->obs.data[index].P  [pos]=psr;
             raw->obs.data[index].D  [pos]=(float)dop;
             raw->obs.data[index].SNR[pos]=
-                0.0<=snr&&snr<255.0?(unsigned char)(snr*4.0+0.5):0;
+                0.0<=snr&&snr<255.0?(unsigned short)(snr*RTK_SNR_SCALE+0.5):0;
             raw->obs.data[index].LLI[pos]=(unsigned char)lli;
             raw->obs.data[index].code[pos]=code;
         }

--- a/src/rcv/ublox.c
+++ b/src/rcv/ublox.c
@@ -291,7 +291,7 @@ static int decode_rxmraw(raw_t *raw)
         raw->obs.data[n].P[0]  =R8(p+ 8)-toff*CLIGHT;
         raw->obs.data[n].D[0]  =R4(p+16);
         prn                    =U1(p+20);
-        raw->obs.data[n].SNR[0]=(unsigned char)(I1(p+22)*4.0+0.5);
+        raw->obs.data[n].SNR[0]=(unsigned char)(I1(p+22)*RTK_SNR_SCALE+0.5);
         raw->obs.data[n].LLI[0]=U1(p+23);
         raw->obs.data[n].code[0]=CODE_L1C;
         
@@ -442,7 +442,7 @@ static int decode_rxmrawx(raw_t *raw)
         raw->obs.data[j].L[f-1]=L;
         raw->obs.data[j].P[f-1]=P;
         raw->obs.data[j].D[f-1]=(float)D;
-        raw->obs.data[j].SNR[f-1]=(unsigned char)(cn0*4);
+        raw->obs.data[j].SNR[f-1]=(unsigned short)(cn0*RTK_SNR_SCALE);
         raw->obs.data[j].LLI[f-1]=(unsigned char)LLI;
         raw->obs.data[j].code[f-1]=(unsigned char)code;
     }
@@ -696,7 +696,7 @@ static int decode_trkmeas(raw_t *raw)
         raw->obs.data[n].P[0]=tau*CLIGHT;
         raw->obs.data[n].L[0]=-adr;
         raw->obs.data[n].D[0]=(float)dop;
-        raw->obs.data[n].SNR[0]=(unsigned char)(snr*4.0);
+        raw->obs.data[n].SNR[0]=(unsigned short)(snr*RTK_SNR_SCALE);
         raw->obs.data[n].code[0]=sys==SYS_CMP?CODE_L1I:CODE_L1C;
         raw->obs.data[n].LLI[0]=raw->lockt[sat-1][1]>0.0?1:0;
         if (sys==SYS_SBS) { /* half-cycle valid */
@@ -815,7 +815,7 @@ static int decode_trkd5(raw_t *raw)
         raw->obs.data[n].P[0]=tau*CLIGHT;
         raw->obs.data[n].L[0]=-adr;
         raw->obs.data[n].D[0]=(float)dop;
-        raw->obs.data[n].SNR[0]=(unsigned char)(snr*4.0);
+        raw->obs.data[n].SNR[0]=(unsigned short)(snr*RTK_SNR_SCALE);
         raw->obs.data[n].code[0]=sys==SYS_CMP?CODE_L1I:CODE_L1C;
         raw->obs.data[n].LLI[0]=raw->lockt[sat-1][1]>0.0?1:0;
         raw->lockt[sat-1][1]=0.0;

--- a/src/rinex.c
+++ b/src/rinex.c
@@ -829,7 +829,7 @@ static int decode_obsdata(FILE *fp, char *buff, double ver, int mask,
             case 0: obs->P[p[i]]=val[i]; obs->code[p[i]]=ind->code[i]; break;
             case 1: obs->L[p[i]]=val[i]; obs->LLI [p[i]]=lli[i];       break;
             case 2: obs->D[p[i]]=(float)val[i];                        break;
-            case 3: obs->SNR[p[i]]=(unsigned char)(val[i]*4.0+0.5);    break;
+            case 3: obs->SNR[p[i]]=(unsigned char)(val[i]*RTK_SNR_SCALE+0.5);    break;
         }
     }
     trace(4,"decode_obsdata: time=%s sat=%2d\n",time_str(obs->time,0),obs->sat);
@@ -2162,7 +2162,7 @@ extern int outrnxobsb(FILE *fp, const rnxopt_t *opt, const obsd_t *obs, int n,
                 case 'P': outrnxobsf(fp,obs[ind[i]].P[k],-1); break;
                 case 'L': outrnxobsf(fp,obs[ind[i]].L[k],obs[ind[i]].LLI[k]); break;
                 case 'D': outrnxobsf(fp,obs[ind[i]].D[k],-1); break;
-                case 'S': outrnxobsf(fp,obs[ind[i]].SNR[k]*0.25,-1); break;
+                case 'S': outrnxobsf(fp,obs[ind[i]].SNR[k]*(1.0/RTK_SNR_SCALE),-1); break;
             }
         }
         if (opt->rnxver>2.99&&fprintf(fp,"\n")==EOF) return 0;

--- a/src/rtcm3.c
+++ b/src/rtcm3.c
@@ -169,9 +169,9 @@ static int lossoflock(rtcm_t *rtcm, int sat, int freq, int lock)
     return lli;
 }
 /* s/n ratio -----------------------------------------------------------------*/
-static unsigned char snratio(double snr)
+static unsigned short snratio(double snr)
 {
-    return (unsigned char)(snr<=0.0||255.5<=snr?0.0:snr*4.0+0.5);
+    return (unsigned short)(snr<=0.0||255.5<=snr?0.0:snr*RTK_SNR_SCALE+0.5);
 }
 /* get observation data index ------------------------------------------------*/
 static int obsindex(obs_t *obs, gtime_t time, int sat)
@@ -297,7 +297,7 @@ static int decode_type1002(rtcm_t *rtcm)
             rtcm->obs.data[index].L[0]=pr1/lam_carr[0]+cp1;
         }
         rtcm->obs.data[index].LLI[0]=lossoflock(rtcm,sat,0,lock1);
-        rtcm->obs.data[index].SNR[0]=snratio(cnr1*0.25);
+        rtcm->obs.data[index].SNR[0]=snratio(cnr1*(1/RTK_SNR_SCALE));
         rtcm->obs.data[index].code[0]=code?CODE_L1P:CODE_L1C;
     }
     return sync?0:1;
@@ -355,7 +355,7 @@ static int decode_type1004(rtcm_t *rtcm)
             rtcm->obs.data[index].L[0]=pr1/lam_carr[0]+cp1;
         }
         rtcm->obs.data[index].LLI[0]=lossoflock(rtcm,sat,0,lock1);
-        rtcm->obs.data[index].SNR[0]=snratio(cnr1*0.25);
+        rtcm->obs.data[index].SNR[0]=snratio(cnr1*(1.0/RTK_SNR_SCALE));
         rtcm->obs.data[index].code[0]=code1?CODE_L1P:CODE_L1C;
         
         if (pr21!=(int)0xFFFFE000) {
@@ -366,7 +366,7 @@ static int decode_type1004(rtcm_t *rtcm)
             rtcm->obs.data[index].L[1]=pr1/lam_carr[1]+cp2;
         }
         rtcm->obs.data[index].LLI[1]=lossoflock(rtcm,sat,1,lock2);
-        rtcm->obs.data[index].SNR[1]=snratio(cnr2*0.25);
+        rtcm->obs.data[index].SNR[1]=snratio(cnr2*(1.0/RTK_SNR_SCALE));
         rtcm->obs.data[index].code[1]=L2codes[code2];
     }
     rtcm->obsflag=!sync;
@@ -595,7 +595,7 @@ static int decode_type1010(rtcm_t *rtcm)
             rtcm->obs.data[index].L[0]=pr1/lam1+cp1;
         }
         rtcm->obs.data[index].LLI[0]=lossoflock(rtcm,sat,0,lock1);
-        rtcm->obs.data[index].SNR[0]=snratio(cnr1*0.25);
+        rtcm->obs.data[index].SNR[0]=snratio(cnr1*(1/RTK_SNR_SCALE));
         rtcm->obs.data[index].code[0]=code?CODE_L1P:CODE_L1C;
     }
     return sync?0:1;
@@ -648,7 +648,7 @@ static int decode_type1012(rtcm_t *rtcm)
             rtcm->obs.data[index].L[0]=pr1/lam1+cp1;
         }
         rtcm->obs.data[index].LLI[0]=lossoflock(rtcm,sat,0,lock1);
-        rtcm->obs.data[index].SNR[0]=snratio(cnr1*0.25);
+        rtcm->obs.data[index].SNR[0]=snratio(cnr1*(1.0/RTK_SNR_SCALE));
         rtcm->obs.data[index].code[0]=code1?CODE_L1P:CODE_L1C;
         
         if (pr21!=(int)0xFFFFE000) {
@@ -660,7 +660,7 @@ static int decode_type1012(rtcm_t *rtcm)
             rtcm->obs.data[index].L[1]=pr1/lam2+cp2;
         }
         rtcm->obs.data[index].LLI[1]=lossoflock(rtcm,sat,1,lock2);
-        rtcm->obs.data[index].SNR[1]=snratio(cnr2*0.25);
+        rtcm->obs.data[index].SNR[1]=snratio(cnr2*(1.0/RTK_SNR_SCALE));
         rtcm->obs.data[index].code[1]=code2?CODE_L2P:CODE_L2C;
     }
     rtcm->obsflag=!sync;
@@ -1890,7 +1890,7 @@ static void save_msm_obs(rtcm_t *rtcm, int sys, msm_h_t *h, const double *r,
                 }
                 rtcm->obs.data[index].LLI[ind[k]]=
                     lossoflock(rtcm,sat,ind[k],lock[j])+(half[j]?3:0);
-                rtcm->obs.data[index].SNR [ind[k]]=(unsigned char)(cnr[j]*4.0);
+                rtcm->obs.data[index].SNR [ind[k]]=(unsigned short)(cnr[j]*RTK_SNR_SCALE);
                 rtcm->obs.data[index].code[ind[k]]=code[k];
             }
             j++;

--- a/src/rtcm3e.c
+++ b/src/rtcm3e.c
@@ -1875,7 +1875,7 @@ static void gen_msm_sig(rtcm_t *rtcm, int sys, int nsat, int nsig, int ncell,
             if (rate &&rate_s !=0.0) rate [cell-1]=rate_s;
             if (lock) lock[cell-1]=lt;
             if (half) half[cell-1]=(data->LLI[j]&2)?1:0;
-            if (cnr ) cnr [cell-1]=(float)(data->SNR[j]*0.25);
+            if (cnr ) cnr [cell-1]=(float)(data->SNR[j]*1.0/RTK_SNR_SCALE);
         }
     }
 }

--- a/src/rtkcmn.c
+++ b/src/rtkcmn.c
@@ -2943,7 +2943,7 @@ extern void traceobs(int level, const obsd_t *obs, int n)
         fprintf(fp_trace," (%2d) %s %-3s rcv%d %13.3f %13.3f %13.3f %13.3f %d %d %d %d %3.1f %3.1f\n",
               i+1,str,id,obs[i].rcv,obs[i].L[0],obs[i].L[1],obs[i].P[0],
               obs[i].P[1],obs[i].LLI[0],obs[i].LLI[1],obs[i].code[0],
-              obs[i].code[1],obs[i].SNR[0]*0.25,obs[i].SNR[1]*0.25);
+              obs[i].code[1],obs[i].SNR[0]*1.0/RTK_SNR_SCALE,obs[i].SNR[1]*1.0/RTK_SNR_SCALE);
     }
     fflush(fp_trace);
 }

--- a/src/rtklib.h
+++ b/src/rtklib.h
@@ -530,12 +530,13 @@ typedef struct {        /* time struct */
     double sec;         /* fraction of second under 1 s */
 } gtime_t;
 
+#define RTK_SNR_SCALE (1000.0)
 typedef struct {        /* observation data record */
     gtime_t time;       /* receiver sampling time (GPST) */
     unsigned char sat,rcv; /* satellite/receiver number */
-    unsigned char SNR [NFREQ+NEXOBS]; /* signal strength (0.25 dBHz) */
     unsigned char LLI [NFREQ+NEXOBS]; /* loss of lock indicator */
     unsigned char code[NFREQ+NEXOBS]; /* code indicator (CODE_???) */
+    unsigned short SNR [NFREQ+NEXOBS]; /* signal strength (1/RTK_SNR_SCALE dBHz) */
     double L[NFREQ+NEXOBS]; /* observation data carrier-phase (cycle) */
     double P[NFREQ+NEXOBS]; /* observation data pseudorange (m) */
     float  D[NFREQ+NEXOBS]; /* observation data doppler frequency (Hz) */
@@ -792,7 +793,7 @@ typedef struct {        /* QZSS LEX message type */
     int type;           /* message type */
     int alert;          /* alert flag */
     unsigned char stat; /* signal tracking status */
-    unsigned char snr;  /* signal C/N0 (0.25 dBHz) */
+    unsigned short snr;  /* signal C/N0 (1.0/RTK_SNR_SCALE dBHz) */
     unsigned int ttt;   /* tracking time (ms) */
     unsigned char msg[212]; /* LEX message data part 1695 bits */
 } lexmsg_t;
@@ -948,7 +949,7 @@ typedef struct {        /* solution status type */
     float resp;         /* pseudorange residual (m) */
     float resc;         /* carrier-phase residual (m) */
     unsigned char flag; /* flags: (vsat<<5)+(slip<<3)+fix */
-    unsigned char snr;  /* signal strength (0.25 dBHz) */
+    unsigned short snr;  /* signal C/N0 (1.0/RTK_SNR_SCALE dBHz) */
     unsigned short lock;  /* lock counter */
     unsigned short outc;  /* outage counter */
     unsigned short slipc; /* slip counter */
@@ -1176,10 +1177,10 @@ typedef struct {        /* satellite status type */
     double resp[NFREQ]; /* residuals of pseudorange (m) */
     double resc[NFREQ]; /* residuals of carrier-phase (m) */
     unsigned char vsat[NFREQ]; /* valid satellite flag */
-    unsigned char snr [NFREQ]; /* signal strength (0.25 dBHz) */
     unsigned char fix [NFREQ]; /* ambiguity fix flag (1:fix,2:float,3:hold) */
     unsigned char slip[NFREQ]; /* cycle-slip flag */
     unsigned char half[NFREQ]; /* half-cycle valid flag */
+    unsigned short snr [NFREQ]; /* signal strength (1.0/RTK_SNR_SCALE dBHz) */
     int lock [NFREQ];   /* lock counter of phase */
     unsigned int outc [NFREQ]; /* obs outage counter of phase */
     unsigned int slipc[NFREQ]; /* cycle-slip counter */

--- a/src/rtkpos.c
+++ b/src/rtkpos.c
@@ -355,7 +355,7 @@ static void outsolstat(rtk_t *rtk)
         for (j=0;j<nfreq;j++) {
             fprintf(fp_stat,"$SAT,%d,%.3f,%s,%d,%.1f,%.1f,%.4f,%.4f,%d,%.0f,%d,%d,%d,%d,%d,%d\n",
                     week,tow,id,j+1,ssat->azel[0]*R2D,ssat->azel[1]*R2D,
-                    ssat->resp[j],ssat->resc[j],ssat->vsat[j],ssat->snr[j]*0.25,
+                    ssat->resp[j],ssat->resc[j],ssat->vsat[j],ssat->snr[j]*(1.0/RTK_SNR_SCALE),
                     ssat->fix[j],ssat->slip[j]&3,ssat->lock[j],ssat->outc[j],
                     ssat->slipc[j],ssat->rejc[j]);
         }
@@ -890,8 +890,8 @@ static void zdres_sat(int base, double r, const obsd_t *obs, const nav_t *nav,
     if (opt->ionoopt==IONOOPT_IFLC) { /* iono-free linear combination */
         if (lam[0]==0.0||lam[1]==0.0) return;
         
-        if (testsnr(base,0,azel[1],obs->SNR[0]*0.25,&opt->snrmask)||
-            testsnr(base,1,azel[1],obs->SNR[1]*0.25,&opt->snrmask)) return;
+        if (testsnr(base,0,azel[1],obs->SNR[0]*(1.0/RTK_SNR_SCALE),&opt->snrmask)||
+            testsnr(base,1,azel[1],obs->SNR[1]*(1.0/RTK_SNR_SCALE),&opt->snrmask)) return;
         
         f1=CLIGHT/lam[0];
         f2=CLIGHT/lam[1];
@@ -911,7 +911,7 @@ static void zdres_sat(int base, double r, const obsd_t *obs, const nav_t *nav,
             if (lam[i]==0.0) continue;
             
             /* check snr mask */
-            if (testsnr(base,i,azel[1],obs->SNR[i]*0.25,&opt->snrmask)) {
+            if (testsnr(base,i,azel[1],obs->SNR[i]*(1.0/RTK_SNR_SCALE),&opt->snrmask)) {
                 continue;
             }
             /* residuals = observable - pseudorange */

--- a/src/rtksvr.c
+++ b/src/rtksvr.c
@@ -1049,7 +1049,7 @@ extern int rtksvrostat(rtksvr_t *svr, int rcv, gtime_t *time, int *sat,
         az  [i]=svr->rtk.ssat[sat[i]-1].azel[0];
         el  [i]=svr->rtk.ssat[sat[i]-1].azel[1];
         for (j=0;j<NFREQ;j++) {
-            snr[i][j]=(int)(svr->obs[rcv][0].data[i].SNR[j]*0.25);
+            snr[i][j]=(int)(svr->obs[rcv][0].data[i].SNR[j]*(1.0/RTK_SNR_SCALE));
         }
         if (svr->rtk.sol.stat==SOLQ_NONE||svr->rtk.sol.stat==SOLQ_SINGLE) {
             vsat[i]=svr->rtk.ssat[sat[i]-1].vs;

--- a/src/solution.c
+++ b/src/solution.c
@@ -1008,7 +1008,7 @@ static int decode_solstat(char *buff, solstat_t *stat)
     stat->resp =(float)resp;
     stat->resc =(float)resc;
     stat->flag =(unsigned char)((vsat<<5)+(slip<<3)+fix);
-    stat->snr  =(unsigned char)(snr*4.0+0.5);
+    stat->snr  =(unsigned char)(snr*RTK_SNR_SCALE+0.5);
     stat->lock =(unsigned short)lock;
     stat->outc =(unsigned short)outc;
     stat->slipc=(unsigned short)slipc;
@@ -1378,7 +1378,7 @@ extern int outnmea_gsv(unsigned char *buff, const sol_t *sol,
                 if (satsys(sats[k],&prn)==SYS_SBS) prn+=33-MINPRNSBS;
                 az =ssat[sats[k]-1].azel[0]*R2D; if (az<0.0) az+=360.0;
                 el =ssat[sats[k]-1].azel[1]*R2D;
-                snr=ssat[sats[k]-1].snr[0]*0.25;
+                snr=ssat[sats[k]-1].snr[0]*(1.0/RTK_SNR_SCALE);
                 p+=sprintf(p,",%02d,%02.0f,%03.0f,%02.0f",prn,el,az,snr);
             }
             else p+=sprintf(p,",,,,");
@@ -1403,7 +1403,7 @@ extern int outnmea_gsv(unsigned char *buff, const sol_t *sol,
                 satsys(sats[k],&prn); prn+=64; /* 65-99 */
                 az =ssat[sats[k]-1].azel[0]*R2D; if (az<0.0) az+=360.0;
                 el =ssat[sats[k]-1].azel[1]*R2D;
-                snr=ssat[sats[k]-1].snr[0]*0.25;
+                snr=ssat[sats[k]-1].snr[0]*(1.0/RTK_SNR_SCALE);
                 p+=sprintf(p,",%02d,%02.0f,%03.0f,%02.0f",prn,el,az,snr);
             }
             else p+=sprintf(p,",,,,");
@@ -1428,7 +1428,7 @@ extern int outnmea_gsv(unsigned char *buff, const sol_t *sol,
                 satsys(sats[k],&prn); /* 1-36 */
                 az =ssat[sats[k]-1].azel[0]*R2D; if (az<0.0) az+=360.0;
                 el =ssat[sats[k]-1].azel[1]*R2D;
-                snr=ssat[sats[k]-1].snr[0]*0.25;
+                snr=ssat[sats[k]-1].snr[0]*(1.0/RTK_SNR_SCALE);
                 p+=sprintf(p,",%02d,%02.0f,%03.0f,%02.0f",prn,el,az,snr);
             }
             else p+=sprintf(p,",,,,");


### PR DESCRIPTION
Rinex files support snr accuracy down to .001
This changes the SNR in rinex files from .25 to .01 accuracy.
My application needs greater accuracy in the snr.

Also uses a #define RTK_SNR_SCALE to make changing scaler easier.
Please review carefully..