### PR TITLE
close file descriptor only when outfile is specified

### DIFF
--- a/util/rnx2rtcm/rnx2rtcm.c
+++ b/util/rnx2rtcm/rnx2rtcm.c
@@ -172,7 +172,7 @@ static int conv_rtcm(const int *type, int n, const char *outfile,
     /* gerate rtcm nav data messages */
     gen_rtcm_nav(time0,&rtcm,nav,index,type,n,fp);
     
-    fclose(fp);
+    if(*outfile) fclose(fp);
     
     /* print statistics  */
     fprintf(stderr,"\n  MT  # OF MSGS\n");


### PR DESCRIPTION
Close file descriptor only when outfile is specified, otherwise stdout may be closed(Even multiple times)