### PR TITLE
rtkrcv fixes

### DIFF
--- a/app/consapp/rtkrcv/rtkrcv.c
+++ b/app/consapp/rtkrcv/rtkrcv.c
@@ -1418,9 +1418,16 @@ static con_t *con_open(int sock, const char *dev)
     
     if (!(con=(con_t *)malloc(sizeof(con_t)))) return NULL;
     
-    if (!(con->vt=vt_open(sock,dev))) {
-        free(con);
-        return NULL;
+    if ( sock == 0 ) {
+        if (!(con->vt=vt_open_stdout())) {
+            free(con);
+            return NULL;
+        }
+    } else {
+        if (!(con->vt=vt_open(sock,dev))) {
+            free(con);
+            return NULL;
+        }
     }
     /* start console thread */
     con->state=1;
@@ -1641,19 +1648,27 @@ int main(int argc, char **argv)
     if (!loadopts(file,rcvopts)||!loadopts(file,sysopts)) {
         fprintf(stderr,"no options file: %s. defaults used\n",file);
     }
+    fprintf(stderr,"> option loaded\n");
+    fflush(stderr);
     getsysopts(&prcopt,solopt,&filopt);
     
     /* read navigation data */
     if (!readnav(NAVIFILE,&svr.nav)) {
         fprintf(stderr,"no navigation data: %s\n",NAVIFILE);
     }
+    fprintf(stderr,"> NAVIFILE\n");
+    fflush(stderr);
     if (outstat>0) {
         rtkopenstat(STATFILE,outstat);
     }
+    fflush(stderr);
     /* open monitor port */
+    fprintf(stderr,"> open monitoring\n"); fflush(stderr);
     if (moniport>0&&!openmoni(moniport)) {
         fprintf(stderr,"monitor port open error: %d\n",moniport);
     }
+    fprintf(stderr,"> open monitoring done\n");
+    fflush(stderr);
     if (port) {
         /* open socket for remote console */
         if ((sock=open_sock(port))<=0) {

--- a/app/consapp/rtkrcv/rtkrcv.c
+++ b/app/consapp/rtkrcv/rtkrcv.c
@@ -1407,6 +1407,7 @@ static void *con_thread(void *arg)
         }
     }
     vt_close(con->vt);
+    con->vt = NULL;
     return 0;
 }
 /* open console --------------------------------------------------------------*/
@@ -1443,7 +1444,10 @@ static void con_close(con_t *con)
     trace(3,"con_close:\n");
     
     if (!con) return;
-    con->state=con->vt->state=0;
+    con->state=0;
+    if ( con->vt ) {
+        con->vt->state = 0;
+    }
     pthread_join(con->thread,NULL);
     free(con);
 }
@@ -1648,27 +1652,19 @@ int main(int argc, char **argv)
     if (!loadopts(file,rcvopts)||!loadopts(file,sysopts)) {
         fprintf(stderr,"no options file: %s. defaults used\n",file);
     }
-    fprintf(stderr,"> option loaded\n");
-    fflush(stderr);
     getsysopts(&prcopt,solopt,&filopt);
     
     /* read navigation data */
     if (!readnav(NAVIFILE,&svr.nav)) {
         fprintf(stderr,"no navigation data: %s\n",NAVIFILE);
     }
-    fprintf(stderr,"> NAVIFILE\n");
-    fflush(stderr);
     if (outstat>0) {
         rtkopenstat(STATFILE,outstat);
     }
-    fflush(stderr);
     /* open monitor port */
-    fprintf(stderr,"> open monitoring\n"); fflush(stderr);
     if (moniport>0&&!openmoni(moniport)) {
         fprintf(stderr,"monitor port open error: %d\n",moniport);
     }
-    fprintf(stderr,"> open monitoring done\n");
-    fflush(stderr);
     if (port) {
         /* open socket for remote console */
         if ((sock=open_sock(port))<=0) {

--- a/app/consapp/rtkrcv/vt.h
+++ b/app/consapp/rtkrcv/vt.h
@@ -15,9 +15,15 @@
 #define MAXHIST     256                 /* size of history buffer */
 
 /* type definitions ----------------------------------------------------------*/
+typedef enum {
+    VT_TYPE_DEV = 0,
+    VT_TYPE_TELNET = 1,
+    VT_TYPE_STDOUT = 2
+} vt_type_t;
+
 typedef struct vt_tag {                 /* virtual console type */
     int state;                          /* state(0:close,1:open) */
-    int type;                           /* type (0:dev,1:telnet) */
+    vt_type_t type;                     /* type (0:dev,1:telnet,2:stdout) */
     int in,out;                         /* input/output file descriptor */
     int n,nesc;                         /* number of line buffer/escape */
     int cur;                            /* cursor position */
@@ -33,6 +39,7 @@ typedef struct vt_tag {                 /* virtual console type */
 
 /* function prototypes -------------------------------------------------------*/
 extern vt_t *vt_open(int sock, const char *dev);
+extern vt_t *vt_open_stdout();
 extern void vt_close(vt_t *vt);
 extern int vt_getc(vt_t *vt, char *c);
 extern int vt_gets(vt_t *vt, char *buff, int n);


### PR DESCRIPTION
- fix segmentation fault when rtkrcv is started in headless mode (no console or stdout only)
- allows console on stdin/stdout