### PR TITLE
Add udp option to rtkrcv

### DIFF
--- a/app/consapp/rtkrcv/rtkrcv.c
+++ b/app/consapp/rtkrcv/rtkrcv.c
@@ -166,6 +166,8 @@ static const char *pathopts[]={         /* path options help */
     "file     : path[::T[::+offset][::xspeed]]",
     "tcpsvr   : :port",
     "tcpcli   : addr:port",
+    "udpsvr   : :port",
+    "udpcli   : addr:port",    
     "ntripsvr : user:passwd@addr:port/mntpnt[:str]",
     "ntripcli : user:passwd@addr:port/mntpnt",
     "ntripc_s : :passwd@:port",

--- a/app/consapp/rtkrcv/rtkrcv.c
+++ b/app/consapp/rtkrcv/rtkrcv.c
@@ -179,7 +179,7 @@ static const char *pathopts[]={         /* path options help */
 #define CONOPT  "0:dms,1:deg,2:xyz,3:enu,4:pyl"
 #define FLGOPT  "0:off,1:std+2:age/ratio/ns"
 #define ISTOPT  "0:off,1:serial,2:file,3:tcpsvr,4:tcpcli,7:ntripcli,8:ftp,9:http"
-#define OSTOPT  "0:off,1:serial,2:file,3:tcpsvr,4:tcpcli,6:ntripsvr,11:ntripc_c"
+#define OSTOPT  "0:off,1:serial,2:file,3:tcpsvr,4:tcpcli,6:ntripsvr,11:ntripc_c,12:udpsvr,13:udpcli"
 #define FMTOPT  "0:rtcm2,1:rtcm3,2:oem4,3:oem3,4:ubx,5:ss2,6:hemis,7:skytraq,8:gw10,9:javad,10:nvs,11:binex,12:rt17,13:sbf,14:cmr,15:tersus,18:sp3"
 #define NMEOPT  "0:off,1:latlon,2:single"
 #define SOLOPT  "0:llh,1:xyz,2:enu,3:nmea,4:stat"


### PR DESCRIPTION
Receivers have a limit of connections, so we created a UDP wrapper to connect to the receiver and distribute any number of connections to rtkrcv servers.
For this to work we added udpsvr and udpcli options
