### PR TITLE
Handle SP3 files with more than 100 satellites tracked

### DIFF
--- a/src/preceph.c
+++ b/src/preceph.c
@@ -88,7 +88,7 @@ static int readsp3h(FILE *fp, gtime_t *time, char *type, int *sats,
         }
         else if (!strncmp(buff,"+ ",2)) { /* satellite id */
             if (ns==0) {
-                ns=(int)str2num(buff,4,2);
+                ns=(int)str2num(buff,3,3);
             }
             for (j=0;j<17&&k<ns;j++) {
                 sys=code2sys(buff[9+3*j]);


### PR DESCRIPTION
For example the GFZ multi-GNSS SP3 files have 126 satellites today.