### PR TITLE
Add missing EXPORT to global variables

### DIFF
--- a/src/rtklib.h
+++ b/src/rtklib.h
@@ -1293,13 +1293,13 @@ typedef struct {        /* GIS type */
 typedef void fatalfunc_t(const char *); /* fatal callback function type */
 
 /* global variables ----------------------------------------------------------*/
-extern const double chisqr[];        /* chi-sqr(n) table (alpha=0.001) */
-extern const prcopt_t prcopt_default; /* default positioning options */
-extern const solopt_t solopt_default; /* default solution output options */
-extern const sbsigpband_t igpband1[9][8]; /* SBAS IGP band 0-8 */
-extern const sbsigpband_t igpband2[2][5]; /* SBAS IGP band 9-10 */
-extern const char *formatstrs[];     /* stream format strings */
-extern opt_t sysopts[];              /* system options table */
+EXPORT extern const double chisqr[];        /* chi-sqr(n) table (alpha=0.001) */
+EXPORT extern const prcopt_t prcopt_default; /* default positioning options */
+EXPORT extern const solopt_t solopt_default; /* default solution output options */
+EXPORT extern const sbsigpband_t igpband1[9][8]; /* SBAS IGP band 0-8 */
+EXPORT extern const sbsigpband_t igpband2[2][5]; /* SBAS IGP band 9-10 */
+EXPORT extern const char *formatstrs[];     /* stream format strings */
+EXPORT extern opt_t sysopts[];              /* system options table */
 
 /* satellites, systems, codes functions --------------------------------------*/
 EXPORT int  satno   (int sys, int prn);


### PR DESCRIPTION
Building RTKLIB as a shared library on Windows fails otherwise.

This cropped up when adding RTKLIB as a package for the Conan package manager:
* https://github.com/conan-io/conan-center-index/pull/17998